### PR TITLE
K3s fixes

### DIFF
--- a/modules/distribution/k3s/output.tf
+++ b/modules/distribution/k3s/output.tf
@@ -4,6 +4,7 @@ output "k3s_user_data" {
   value = templatefile("${path.module}/server_config.yaml.tpl",
     {
       k3s_config  = var.k3s_config == null ? "false" : var.k3s_config,
+      k3s_channel = var.k3s_channel == null ? "stable" : var.k3s_channel,
       k3s_token   = local.k3s_token,
       k3s_version = var.k3s_version == null ? "false" : var.k3s_version,
       server_ip   = var.first_server_ip == null ? "false" : var.first_server_ip

--- a/modules/distribution/k3s/server_config.yaml.tpl
+++ b/modules/distribution/k3s/server_config.yaml.tpl
@@ -5,9 +5,11 @@ PUBLIC_IP=$(curl ifconfig.io)
 cat > /tmp/config.yaml <<EOF
 token: ${k3s_token}
 %{ if server_ip != "false" }
-server: https://${server_ip}:9345
+server: https://${server_ip}:6443
+%{ else }
+cluster-init: true
 %{ endif }
-
+node-external-ip: $PUBLIC_IP
 tls-san:
   - "$PUBLIC_IP"
   - "$PUBLIC_IP.sslip.io"
@@ -20,15 +22,10 @@ EOF
 export INSTALL_K3S_VERSION=${k3s_version}
 %{ endif }
 
-curl https://get.k3s.io | INSTALL_K3S_EXEC="server --node-external-ip=$PUBLIC_IP" sh -
 mkdir -p /etc/rancher/k3s
 cp /tmp/config.yaml /etc/rancher/k3s
-#systemctl enable k3s-server
-#systemctl start k3s-server
+curl https://get.k3s.io | INSTALL_K3S_CHANNEL=${k3s_channel} sh -
 
 cat >> /etc/profile <<EOF
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-export CRI_CONFIG_FILE=/var/lib/rancher/k3s/agent/etc/crictl.yaml
-PATH="$PATH:/var/lib/rancher/k3s/bin"
 alias k=kubectl
 EOF

--- a/modules/distribution/k3s/variables.tf
+++ b/modules/distribution/k3s/variables.tf
@@ -15,6 +15,12 @@ variable "k3s_token" {
   default     = null
 }
 
+variable "k3s_channel" {
+  type        = string
+  description = "K3s channel to use, the latest patch version for the provided minor version will be used"
+  default     = null
+}
+
 variable "k3s_config" {
   description = "Additional k3s configuration to add to the config.yaml file"
   default     = null

--- a/modules/distribution/rke2/main.tf
+++ b/modules/distribution/rke2/main.tf
@@ -1,5 +1,4 @@
 locals {
-  # create_token = var.rke2_token == null && var.first_server_ip == null ? true : false
   rke2_token = var.rke2_token == null && var.first_server_ip == null ? random_password.token.result : var.rke2_token
 }
 

--- a/modules/distribution/rke2/server_config.yaml.tpl
+++ b/modules/distribution/rke2/server_config.yaml.tpl
@@ -7,8 +7,7 @@ token: ${rke2_token}
 %{ if server_ip != "false" }
 server: https://${server_ip}:9345
 %{ endif }
-node-external-ip:
-  - $PUBLIC_IP
+node-external-ip: $PUBLIC_IP
 tls-san:
   - "$PUBLIC_IP"
   - "$PUBLIC_IP.sslip.io"

--- a/recipes/upstream/aws/k3s/main.tf
+++ b/recipes/upstream/aws/k3s/main.tf
@@ -71,5 +71,5 @@ module "rancher_install" {
   rancher_replicas           = var.instance_count
   rancher_bootstrap_password = var.rancher_password
   rancher_version            = var.rancher_version
-  dependency                 = module.k3s_first_server.dependency
+  dependency                 = var.instance_count > 1 ? module.k3s_additional_servers.dependency : module.k3s_first_server.dependency
 }

--- a/recipes/upstream/aws/k3s/main.tf
+++ b/recipes/upstream/aws/k3s/main.tf
@@ -2,6 +2,7 @@ module "k3s_first" {
   source      = "../../../../modules/distribution/k3s"
   k3s_token   = var.k3s_token
   k3s_version = var.k3s_version
+  k3s_channel = var.k3s_channel
   k3s_config  = var.k3s_config
 }
 
@@ -23,6 +24,7 @@ module "k3s_additional" {
   source          = "../../../../modules/distribution/k3s"
   k3s_token       = module.k3s_first.k3s_token
   k3s_version     = var.k3s_version
+  k3s_channel     = var.k3s_channel
   k3s_config      = var.k3s_config
   first_server_ip = module.k3s_first_server.instances_private_ip[0]
 }

--- a/recipes/upstream/aws/k3s/terraform.tfvars.example
+++ b/recipes/upstream/aws/k3s/terraform.tfvars.example
@@ -23,8 +23,9 @@ prefix = "my-name-here"
 ## -- Rancher version to use when installing the Rancher helm chart, otherwise use the latest in the stable repository
 # rancher_version = "2.7.3"
 
-## -- Override the default k8s version used by K3S
+## -- Override the default k8s version or channel used by K3S
 # k3s_version = "v1.24.14+k3s1"
+k3s_channel = "v1.25"
 
 ## -- Number of EC2 instances to launch
 instance_count = 1

--- a/recipes/upstream/aws/k3s/variables.tf
+++ b/recipes/upstream/aws/k3s/variables.tf
@@ -33,6 +33,12 @@ variable "k3s_version" {
   default     = null
 }
 
+variable "k3s_channel" {
+  type        = string
+  description = "K3s channel to use, the latest patch version for the provided minor version will be used"
+  default     = null
+}
+
 variable "k3s_token" {
   description = "Token to use when configuring k3s nodes"
   default     = null

--- a/recipes/upstream/aws/rke2/main.tf
+++ b/recipes/upstream/aws/rke2/main.tf
@@ -69,5 +69,5 @@ module "rancher_install" {
   rancher_replicas           = var.instance_count
   rancher_bootstrap_password = var.rancher_password
   rancher_version            = var.rancher_version
-  dependency                 = module.rke2_first_server.dependency
+  dependency                 = var.instance_count > 1 ? module.rke2_additional_servers.dependency : module.rke2_first_server.dependency
 }


### PR DESCRIPTION
Resolves: https://github.com/rancherlabs/tf-rancher-up/issues/63

- Add `k3s_channel`, defaults in tfvars to v1.25 to limit minor version and resolve Rancher chart install
- Adjust node-external-ip
- Use the k3s port of `6443` and set `cluster-init` (etcd embedded) for first node, resolves an issue with additional nodes not joining
- Improve dependency handling when more than one `instance_count` is used (Rancher module depends on the additional nodes during destroy)