### PR TITLE
Set nullable for variables in infra/aws module

### DIFF
--- a/modules/infra/aws/variables.tf
+++ b/modules/infra/aws/variables.tf
@@ -32,18 +32,21 @@ variable "instance_type" {
   type        = string
   description = "Instance type used for all EC2 instances"
   default     = "t3.medium"
+  nullable    = false
 }
 
 variable "instance_disk_size" {
   type        = string
   description = "Specify root disk size (GB)"
   default     = "80"
+  nullable    = false
 }
 
 variable "instance_count" {
   type        = number
   description = "Number of EC2 instances to create"
   default     = 3
+  nullable    = false
 }
 
 variable "subnet_id" {
@@ -56,6 +59,7 @@ variable "create_ssh_key_pair" {
   type        = bool
   description = "Specify if a new SSH key pair needs to be created for the instances"
   default     = false
+  nullable    = false
 }
 
 variable "ssh_key_pair_name" {
@@ -80,6 +84,7 @@ variable "create_security_group" {
   type        = bool
   description = "Should create the security group associated with the instance(s)"
   default     = true
+  nullable    = false
 }
 
 # TODO: Add a check based on above value
@@ -93,12 +98,14 @@ variable "ssh_username" {
   type        = string
   description = "Username used for SSH with sudo access"
   default     = "ubuntu"
+  nullable    = false
 }
 
 variable "spot_instances" {
   type        = bool
   description = "Use spot instances"
   default     = false
+  nullable    = false
 }
 
 variable "user_data" {

--- a/recipes/upstream/aws/k3s/variables.tf
+++ b/recipes/upstream/aws/k3s/variables.tf
@@ -24,13 +24,13 @@ variable "prefix" {
 variable "instance_count" {
   type        = number
   description = "Number of EC2 instances to create"
-  default     = 3
+  default     = null
 }
 
 variable "instance_type" {
   type        = string
   description = "Instance type used for all EC2 instances"
-  default     = ""
+  default     = null
 }
 
 variable "k3s_version" {
@@ -76,7 +76,7 @@ variable "rancher_version" {
 variable "create_ssh_key_pair" {
   type        = bool
   description = "Specify if a new SSH key pair needs to be created for the instances"
-  default     = false
+  default     = null
 }
 
 variable "ssh_key_pair_name" {
@@ -100,5 +100,5 @@ variable "ssh_username" {
 variable "spot_instances" {
   type        = bool
   description = "Use spot instances"
-  default     = false
+  default     = null
 }

--- a/recipes/upstream/aws/rke/variables.tf
+++ b/recipes/upstream/aws/rke/variables.tf
@@ -24,19 +24,19 @@ variable "prefix" {
 variable "instance_count" {
   type        = number
   description = "Number of EC2 instances to create"
-  default     = 3
+  default     = null
 }
 
 variable "instance_type" {
   type        = string
   description = "Instance type used for all EC2 instances"
-  default     = ""
+  default     = null
 }
 
 variable "instance_disk_size" {
   type        = string
   description = "Specify root disk size (GB)"
-  default     = "80"
+  default     = null
 }
 
 variable "kube_config_path" {
@@ -78,7 +78,7 @@ variable "rancher_version" {
 variable "create_ssh_key_pair" {
   type        = bool
   description = "Specify if a new SSH key pair needs to be created for the instances"
-  default     = false
+  default     = null
 }
 
 variable "ssh_key_pair_name" {
@@ -102,7 +102,7 @@ variable "ssh_username" {
 variable "spot_instances" {
   type        = bool
   description = "Use spot instances"
-  default     = false
+  default     = null
 }
 
 variable "subnet_id" {
@@ -114,7 +114,7 @@ variable "subnet_id" {
 variable "create_security_group" {
   type        = bool
   description = "Should create the security group associated with the instance(s)"
-  default     = true
+  default     = null
 }
 
 # TODO: Add a check based on above value

--- a/recipes/upstream/aws/rke2/terraform.tfvars.example
+++ b/recipes/upstream/aws/rke2/terraform.tfvars.example
@@ -24,7 +24,7 @@ prefix = "my-name-here"
 # rancher_version = "2.7.3"
 
 ## -- Override the default k8s version used by RKE2
-# kubernetes_version = "v1.25.10+rke2r1"
+# rke2_version = "v1.25.10+rke2r1"
 
 ## -- Number and type of EC2 instances to launch
 instance_count = 1

--- a/recipes/upstream/aws/rke2/variables.tf
+++ b/recipes/upstream/aws/rke2/variables.tf
@@ -24,13 +24,13 @@ variable "prefix" {
 variable "instance_count" {
   type        = number
   description = "Number of EC2 instances to create"
-  default     = 3
+  default     = null
 }
 
 variable "instance_type" {
   type        = string
   description = "Instance type used for all EC2 instances"
-  default     = ""
+  default     = null
 }
 
 variable "rke2_version" {
@@ -70,7 +70,7 @@ variable "rancher_version" {
 variable "create_ssh_key_pair" {
   type        = bool
   description = "Specify if a new SSH key pair needs to be created for the instances"
-  default     = false
+  default     = null
 }
 
 variable "ssh_key_pair_name" {
@@ -94,5 +94,5 @@ variable "ssh_username" {
 variable "spot_instances" {
   type        = bool
   description = "Use spot instances"
-  default     = false
+  default     = null
 }


### PR DESCRIPTION
A newish variable option in terraform - `nullable`, conditionally uses the underlying module variable default when no variable is passed from the calling module.
  * https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values

This consolidates the defaults for AWS variables in one place