### PR TITLE
Changed the targeted release namespace behavior of the rancher module

### DIFF
--- a/modules/rancher/main.tf
+++ b/modules/rancher/main.tf
@@ -120,6 +120,7 @@ resource "helm_release" "rancher" {
   name                = "rancher"
   chart               = "rancher"
   create_namespace    = true
+  namespace           = var.rancher_namespace
   repository          = var.helm_repository != null ? var.helm_repository : "https://releases.rancher.com/server-charts/stable"
   repository_username = var.helm_username != null ? var.helm_username : null
   repository_password = var.helm_password != null ? var.helm_password : null

--- a/modules/rancher/variables.tf
+++ b/modules/rancher/variables.tf
@@ -74,6 +74,12 @@ variable "rancher_hostname" {
   type        = string
 }
 
+variable "rancher_namespace" {
+  description = "The Rancher release will be deployed to this namespace"
+  type        = string
+  default     = "cattle-system"
+}
+
 variable "rancher_replicas" {
   description = "Value for replicas when installing the Rancher helm chart"
   default     = 3


### PR DESCRIPTION
- The rancher module can now receive a target deployment namespace through the 'rancher_namespace' variable. Deploys to the 'cattle-system' namespace by default.