### PR TITLE
Updated the Google Provider to the latest version available and made the GKE cluster version dynamic

### DIFF
--- a/modules/distribution/gke/docs.md
+++ b/modules/distribution/gke/docs.md
@@ -23,12 +23,13 @@ No modules.
 | [google_container_node_pool.primary_nodes](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool) | resource |
 | [local_file.kube_config_yaml](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.kube_config_yaml_backup](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [google_container_engine_versions.gke_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_engine_versions) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Supported Google Kubernetes Engine for Rancher Manager | `string` | `"1.28.8-gke.1095000"` | no |
+| <a name="input_cluster_version_prefix"></a> [cluster\_version\_prefix](#input\_cluster\_version\_prefix) | Supported Google Kubernetes Engine for Rancher Manager | `string` | `"1.28."` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Type of the disk attached to each node (e.g. 'pd-standard', 'pd-ssd' or 'pd-balanced') | `string` | `"pd-balanced"` | no |
 | <a name="input_image_type"></a> [image\_type](#input\_image\_type) | The default image type used by NAP once a new node pool is being created. The value must be one of the [COS\_CONTAINERD, COS, UBUNTU\_CONTAINERD, UBUNTU]. NOTE: COS AND UBUNTU are deprecated as of GKE 1.24 | `string` | `"cos_containerd"` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | The number of nodes per instance group | `number` | `1` | no |

--- a/modules/distribution/gke/variables.tf
+++ b/modules/distribution/gke/variables.tf
@@ -72,8 +72,8 @@ variable "subnet" {
   default     = null
 }
 
-variable "cluster_version" {
-  default     = "1.28.8-gke.1095000"
+variable "cluster_version_prefix" {
+  default     = "1.28."
   description = "Supported Google Kubernetes Engine for Rancher Manager"
 }
 

--- a/recipes/upstream/google-cloud/gke/docs.md
+++ b/recipes/upstream/google-cloud/gke/docs.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 4.75.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.32.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.0 |
 
@@ -11,9 +11,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.0.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.13.2 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.30.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
 
 ## Modules
 

--- a/recipes/upstream/google-cloud/gke/provider.tf
+++ b/recipes/upstream/google-cloud/gke/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.75.0"
+      version = "5.32.0"
     }
 
     kubernetes = {

--- a/recipes/upstream/google-cloud/gke/terraform.tfvars.example
+++ b/recipes/upstream/google-cloud/gke/terraform.tfvars.example
@@ -21,7 +21,7 @@ region = "<REGION>"
 # subnet = null
 
 ## -- Supported Google Kubernetes Engine for Rancher Manager
-# cluster_version = "1.28.8-gke.1095000"
+# cluster_version_prefix = "1.28."
 
 #Ref. https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/
 

--- a/recipes/upstream/google-cloud/gke/variables.tf
+++ b/recipes/upstream/google-cloud/gke/variables.tf
@@ -58,7 +58,7 @@ variable "region" {
 
 # variable "subnet" {}
 
-# variable "cluster_version" {}
+# variable "cluster_version_prefix" {}
 
 # variable "instance_count" {}
 

--- a/recipes/upstream/google-cloud/k3s/docs.md
+++ b/recipes/upstream/google-cloud/k3s/docs.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 4.75.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.32.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.0 |
 | <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.6.0 |

--- a/recipes/upstream/google-cloud/k3s/provider.tf
+++ b/recipes/upstream/google-cloud/k3s/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.75.0"
+      version = "5.32.0"
     }
 
     ssh = {

--- a/recipes/upstream/google-cloud/rke/docs.md
+++ b/recipes/upstream/google-cloud/rke/docs.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 4.75.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.32.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.0 |
 | <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.6.0 |

--- a/recipes/upstream/google-cloud/rke/provider.tf
+++ b/recipes/upstream/google-cloud/rke/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.75.0"
+      version = "5.32.0"
     }
 
     ssh = {

--- a/recipes/upstream/google-cloud/rke2/docs.md
+++ b/recipes/upstream/google-cloud/rke2/docs.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 4.75.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.32.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.0 |
 | <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.6.0 |

--- a/recipes/upstream/google-cloud/rke2/provider.tf
+++ b/recipes/upstream/google-cloud/rke2/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.75.0"
+      version = "5.32.0"
     }
 
     ssh = {

--- a/tests/modules/distribution/gke/docs.md
+++ b/tests/modules/distribution/gke/docs.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 4.75.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.32.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.0 |
 
 ## Providers

--- a/tests/modules/distribution/gke/provider.tf
+++ b/tests/modules/distribution/gke/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.75.0"
+      version = "5.32.0"
     }
 
     kubernetes = {

--- a/tests/modules/infra/google-cloud/docs.md
+++ b/tests/modules/infra/google-cloud/docs.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 4.75.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.32.0 |
 
 ## Providers
 

--- a/tests/modules/infra/google-cloud/provider.tf
+++ b/tests/modules/infra/google-cloud/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.75.0"
+      version = "5.32.0"
     }
   }
 


### PR DESCRIPTION
Issue #111 

Fixed #112 <-- Google has total control over published GKE versions, and the one set in this PR is no longer available.
I made the choice of version dynamic, simply using the prefix (example 1.28.).

The doc has also been modified.