### PR TITLE
Add Digitalocean Loadbalancer

### DIFF
--- a/modules/distribution/rke/main.tf
+++ b/modules/distribution/rke/main.tf
@@ -42,6 +42,11 @@ resource "rke_cluster" "this" {
     ssh_key      = var.bastion_host != null ? var.bastion_host.ssh_key : ""
   }
 
+  authentication {
+    sans     = [for hostname in var.additional_hostnames : "$hostname"]
+    strategy = "x509"
+  }
+
   kubernetes_version = var.kubernetes_version
   ssh_agent_auth     = var.ssh_agent_auth
   addon_job_timeout  = 120

--- a/modules/distribution/rke/variables.tf
+++ b/modules/distribution/rke/variables.tf
@@ -150,3 +150,9 @@ variable "create_kubeconfig_file" {
   description = "Boolean flag to generate a kubeconfig file (mostly used for dev only)"
   default     = true
 }
+
+variable "additional_hostnames" {
+  description = "List of additional hostnames and IPs to include in the api server PKI cert"
+  type        = list(string)
+  default     = null
+}

--- a/modules/infra/digitalocean/outputs.tf
+++ b/modules/infra/digitalocean/outputs.tf
@@ -20,6 +20,17 @@ output "droplet_ips" {
   ]
 }
 
+output "droplet_ids" {
+  value = digitalocean_droplet.droplet[*].id
+}
+output "k8s_api_loadbalancer_ip" {
+  value = var.create_k8s_api_loadbalancer ? digitalocean_loadbalancer.k8s_api_loadbalancer[0].ip : null
+}
+
+output "https_loadbalancer_ip" {
+  value = var.create_https_loadbalancer ? digitalocean_loadbalancer.https_loadbalancer[0].ip : null
+}
+
 output "ssh_key_path" {
   value = var.create_ssh_key_pair ? local_file.private_key_pem[0].filename : var.ssh_key_pair_path
 }

--- a/modules/infra/digitalocean/variables.tf
+++ b/modules/infra/digitalocean/variables.tf
@@ -91,3 +91,17 @@ variable "user_data" {
   description = "User data content for EC2 instance(s)"
   default     = null
 }
+
+variable "create_k8s_api_loadbalancer" {
+  type        = bool
+  description = "Specify if a loadbalancer for port 6443 needs to be created for the instances"
+  default     = false
+  nullable    = false
+}
+
+variable "create_https_loadbalancer" {
+  type        = bool
+  description = "Specify if a loadbalancer for port 443 needs to be created for the instances"
+  default     = false
+  nullable    = false
+}

--- a/recipes/upstream/digitalocean/rke/main.tf
+++ b/recipes/upstream/digitalocean/rke/main.tf
@@ -16,7 +16,7 @@ module "upstream-cluster" {
   ssh_private_key_path = var.ssh_private_key_path
   user_data = templatefile("${path.module}/cloud-config.yaml",
   {})
-  create_https_loadbalancer = var.create_https_loadbalancer
+  create_https_loadbalancer   = var.create_https_loadbalancer
   create_k8s_api_loadbalancer = var.create_k8s_api_loadbalancer
 }
 

--- a/recipes/upstream/digitalocean/rke/main.tf
+++ b/recipes/upstream/digitalocean/rke/main.tf
@@ -1,3 +1,7 @@
+locals {
+  rancher_hostname = var.create_https_loadbalancer ? module.upstream-cluster.https_loadbalancer_ip : module.upstream-cluster.droplets_public_ip[0]
+}
+
 module "upstream-cluster" {
   source               = "../../../../modules/infra/digitalocean"
   prefix               = var.prefix
@@ -12,6 +16,8 @@ module "upstream-cluster" {
   ssh_private_key_path = var.ssh_private_key_path
   user_data = templatefile("${path.module}/cloud-config.yaml",
   {})
+  create_https_loadbalancer = var.create_https_loadbalancer
+  create_k8s_api_loadbalancer = var.create_k8s_api_loadbalancer
 }
 
 module "rke" {
@@ -23,6 +29,7 @@ module "rke" {
   kube_config_path     = pathexpand(var.kube_config_path)
   kube_config_filename = var.kube_config_filename
   kubernetes_version   = var.kubernetes_version
+  additional_hostnames = [module.upstream-cluster.k8s_api_loadbalancer_ip]
 
   rancher_nodes = [for droplet_ips in module.upstream-cluster.droplet_ips :
     {
@@ -37,13 +44,16 @@ module "rke" {
 }
 
 module "rancher_install" {
-  source                     = "../../../../modules/rancher"
-  dependency                 = module.rke.dependency
-  kubeconfig_file            = module.rke.rke_kubeconfig_filename
-  rancher_hostname           = join(".", ["rancher", module.upstream-cluster.droplets_public_ip[0], "sslip.io"])
-  rancher_replicas           = var.droplet_count
-  rancher_bootstrap_password = var.rancher_password
-  rancher_password           = var.rancher_password
-  rancher_version            = var.rancher_version
-  wait                       = var.wait
+  source                           = "../../../../modules/rancher"
+  dependency                       = module.rke.dependency
+  kubeconfig_file                  = module.rke.rke_kubeconfig_filename
+  rancher_hostname                 = join(".", ["rancher", local.rancher_hostname, "sslip.io"])
+  rancher_replicas                 = var.droplet_count
+  rancher_bootstrap_password       = var.rancher_password
+  rancher_password                 = var.rancher_password
+  rancher_version                  = var.rancher_version
+  rancher_helm_repository          = var.rancher_helm_repository
+  rancher_helm_repository_username = var.rancher_helm_repository_username
+  rancher_helm_repository_password = var.rancher_helm_repository_password
+  wait                             = var.wait
 }

--- a/recipes/upstream/digitalocean/rke/outputs.tf
+++ b/recipes/upstream/digitalocean/rke/outputs.tf
@@ -7,7 +7,7 @@ output "droplets_private_ip" {
 }
 
 output "rancher_hostname" {
-  value = "https://${join(".", ["rancher", module.upstream-cluster.droplets_public_ip[0], "sslip.io"])}"
+  value = module.rancher_install.rancher_hostname
 }
 
 output "rancher_password" {
@@ -21,3 +21,15 @@ output "ssh_key_path" {
 output "ssh_key_pair_name" {
   value = module.upstream-cluster.ssh_key_pair_name
 }
+
+output "droplet_ids" {
+  value = module.upstream-cluster.droplet_ids
+}
+output "k8s_api_loadbalancer_ip" {
+  value = module.upstream-cluster.k8s_api_loadbalancer_ip
+}
+
+output "https_loadbalancer_ip" {
+  value = module.upstream-cluster.https_loadbalancer_ip
+}
+

--- a/recipes/upstream/digitalocean/rke/terraform.tfvars.example
+++ b/recipes/upstream/digitalocean/rke/terraform.tfvars.example
@@ -45,3 +45,9 @@
 
 # DigitalOcean authentication token 
 # do_token = ""
+
+# Create a loadbalancer resource to route https traffic across all droplets
+# create_https_loadbalancer = false
+
+# Create a loadbalancer resource to route kubernetes apiserver traffic across all droplets
+# create_k8s_api_loadbalancer = false

--- a/recipes/upstream/digitalocean/rke/variables.tf
+++ b/recipes/upstream/digitalocean/rke/variables.tf
@@ -122,7 +122,39 @@ variable "rancher_version" {
   type        = string
 }
 
+variable "rancher_helm_repository" {
+  description = "Helm repository for Rancher chart"
+  default     = null
+  type        = string
+}
+
+variable "rancher_helm_repository_username" {
+  description = "Private Rancher helm repository username"
+  default     = null
+  type        = string
+}
+
+variable "rancher_helm_repository_password" {
+  description = "Private Rancher helm repository password"
+  default     = null
+  type        = string
+}
+
 variable "wait" {
   description = "An optional wait before installing the Rancher helm chart"
   default     = "20s"
+}
+
+variable "create_k8s_api_loadbalancer" {
+  type        = bool
+  description = "Specify if a loadbalancer for port 6443 needs to be created for the instances"
+  default     = false
+  nullable    = false
+}
+
+variable "create_https_loadbalancer" {
+  type        = bool
+  description = "Specify if a loadbalancer for port 443 needs to be created for the instances"
+  default     = false
+  nullable    = false
 }


### PR DESCRIPTION
Added support to accept additional host names in rke module
Added load-balancers for kube-apiserver (6443) and HTTPS (443) traffic
Added support for the following in DigitalOcean recipe:
- User defined rancher helm repository
- DO load-balancer IP as the Rancher hostname