### PR TITLE
fix module rke2_first_server instance_security_group var typo

### DIFF
--- a/recipes/upstream/aws/rke2/main.tf
+++ b/recipes/upstream/aws/rke2/main.tf
@@ -24,7 +24,7 @@ module "rke2_first_server" {
   spot_instances          = var.spot_instances
   aws_region              = var.aws_region
   create_security_group   = var.create_security_group
-  instance_security_group = var.ssh_key_pair_name
+  instance_security_group = var.instance_security_group
   subnet_id               = var.subnet_id
   user_data               = module.rke2_first.rke2_user_data
 }


### PR DESCRIPTION
The upstream aws rke2 module instance_security_group was using ssh_key_pair_name variable