### PR TITLE
SSH keypair fix

### DIFF
--- a/recipes/upstream/aws/k3s/main.tf
+++ b/recipes/upstream/aws/k3s/main.tf
@@ -47,7 +47,6 @@ module "k3s_additional_servers" {
   instance_disk_size      = var.instance_disk_size
   create_ssh_key_pair     = false
   ssh_key_pair_name       = module.k3s_first_server.ssh_key_pair_name
-  ssh_key_pair_path       = pathexpand(module.k3s_first_server.ssh_key_path)
   ssh_username            = var.ssh_username
   spot_instances          = var.spot_instances
   tag_begin               = 2
@@ -57,7 +56,6 @@ module "k3s_additional_servers" {
   subnet_id               = var.subnet_id
   user_data               = module.k3s_additional.k3s_server_user_data
 }
-
 
 module "k3s_workers" {
   source                  = "../../../../modules/infra/aws"

--- a/recipes/upstream/aws/k3s/terraform.tfvars.example
+++ b/recipes/upstream/aws/k3s/terraform.tfvars.example
@@ -42,7 +42,7 @@ worker_instance_count = 1
 ## -- (A) Create a new keypair in AWS
 create_ssh_key_pair = true
 ## -- Override the default (./${prefix}_ssh_private_key.pem) path where this SSH key is written
-# ssh_private_key_path = "/path/to/private/key.pem"
+# ssh_key_pair_path = "/path/to/private/key.pem"
 
 ## -- (B) Provide an existing keypair name in AWS to use for nodes, the matching private key file for this keypair also must be provided so RKE can SSH to the launched nodes
 # ssh_key_pair_name = "aws_keypair_name"

--- a/recipes/upstream/aws/rke/terraform.tfvars.example
+++ b/recipes/upstream/aws/rke/terraform.tfvars.example
@@ -37,7 +37,7 @@ instance_count = 1
 ## -- (A) Create a new keypair in AWS
 create_ssh_key_pair = true
 ## -- Override the default (./${prefix}_ssh_private_key.pem) path where this SSH key is written
-# ssh_private_key_path = "/path/to/private/key.pem"
+# ssh_key_pair_path = "/path/to/private/key.pem"
 
 ## -- (B) Provide an existing keypair name in AWS to use for nodes, the matching private key file for this keypair also must be provided so RKE can SSH to the launched nodes
 # ssh_key_pair_name = "aws_keypair_name"

--- a/recipes/upstream/aws/rke/variables.tf
+++ b/recipes/upstream/aws/rke/variables.tf
@@ -118,7 +118,7 @@ variable "rancher_bootstrap_password" {
 
 variable "rancher_password" {
   description = "Password to use for Rancher (min 12 characters)"
-  default     = null
+  default     = "initial-admin-password"
   type        = string
 
   validation {

--- a/recipes/upstream/aws/rke2/main.tf
+++ b/recipes/upstream/aws/rke2/main.tf
@@ -45,7 +45,6 @@ module "rke2_additional_servers" {
   instance_disk_size      = var.instance_disk_size
   create_ssh_key_pair     = false
   ssh_key_pair_name       = module.rke2_first_server.ssh_key_pair_name
-  ssh_key_pair_path       = module.rke2_first_server.ssh_key_path
   ssh_username            = var.ssh_username
   spot_instances          = var.spot_instances
   tag_begin               = 2

--- a/recipes/upstream/aws/rke2/terraform.tfvars.example
+++ b/recipes/upstream/aws/rke2/terraform.tfvars.example
@@ -40,7 +40,7 @@ instance_count = 1
 ## -- (A) Create a new keypair in AWS
 create_ssh_key_pair = true
 ## -- Override the default (./${prefix}_ssh_private_key.pem) path where this SSH key is written
-# ssh_private_key_path = "/path/to/private/key.pem"
+# ssh_key_pair_path = "/path/to/private/key.pem"
 
 ## -- (B) Provide an existing keypair name in AWS to use for nodes, the matching private key file for this keypair also must be provided so RKE can SSH to the launched nodes
 # ssh_key_pair_name = "aws_keypair_name"

--- a/recipes/upstream/aws/rke2/variables.tf
+++ b/recipes/upstream/aws/rke2/variables.tf
@@ -111,7 +111,7 @@ variable "rancher_bootstrap_password" {
 
 variable "rancher_password" {
   description = "Password to use for Rancher (min 12 characters)"
-  default     = null
+  default     = "initial-admin-password"
   type        = string
 
   validation {

--- a/recipes/upstream/google-cloud/gke/variables.tf
+++ b/recipes/upstream/google-cloud/gke/variables.tf
@@ -114,7 +114,9 @@ variable "rancher_hostname" {
 }
 
 variable "rancher_password" {
-  type = string
+  description = "Password to use for bootstrapping Rancher (min 12 characters)"
+  default     = "initial-admin-password"
+  type        = string
 
   validation {
     condition     = length(var.rancher_password) >= 12

--- a/recipes/upstream/google-cloud/k3s/variables.tf
+++ b/recipes/upstream/google-cloud/k3s/variables.tf
@@ -157,7 +157,9 @@ variable "bootstrap_rancher" {
 variable "rancher_hostname" {}
 
 variable "rancher_password" {
-  type = string
+  description = "Password to use for bootstrapping Rancher (min 12 characters)"
+  default     = "initial-admin-password"
+  type        = string
 
   validation {
     condition     = length(var.rancher_password) >= 12

--- a/recipes/upstream/google-cloud/rke/variables.tf
+++ b/recipes/upstream/google-cloud/rke/variables.tf
@@ -112,7 +112,9 @@ variable "bootstrap_rancher" {
 variable "rancher_hostname" {}
 
 variable "rancher_password" {
-  type = string
+  description = "Password to use for bootstrapping Rancher (min 12 characters)"
+  default     = "initial-admin-password"
+  type        = string
 
   validation {
     condition     = length(var.rancher_password) >= 12

--- a/recipes/upstream/google-cloud/rke2/variables.tf
+++ b/recipes/upstream/google-cloud/rke2/variables.tf
@@ -136,7 +136,9 @@ variable "bootstrap_rancher" {
 variable "rancher_hostname" {}
 
 variable "rancher_password" {
-  type = string
+  description = "Password to use for bootstrapping Rancher (min 12 characters)"
+  default     = "initial-admin-password"
+  type        = string
 
   validation {
     condition     = length(var.rancher_password) >= 12


### PR DESCRIPTION
- Updated variable naming
- Removal of `ssh_key_pair_path` on additional servers, as only a keypair name is needed to launch the additional instances (created by the first instance and re-used)

```
│ Error: Invalid function argument
│ 
│   on ../../../../modules/infra/aws/outputs.tf line 29, in output "ssh_key":
│   29:   value = var.create_ssh_key_pair ? tls_private_key.ssh_private_key[0].private_key_openssh : (var.ssh_key_pair_path != null ? file(pathexpand(var.ssh_key_pair_path)) : var.ssh_key)
│     ├────────────────
│     │ while calling file(path)
│     │ var.ssh_key_pair_path is "..../recipes/upstream/aws/rke2/xxxx-ssh_private_key.pem"
│ 
│ Invalid value for "path" parameter: no file exists at "/..../recipes/upstream/aws/rke2/xxx-ssh_private_key.pem"; this function works only
```

Note: PR branch is based on https://github.com/rancher/tf-rancher-up/pull/163 so should be merged first