### PR TITLE
SSH key fix

### DIFF
--- a/modules/infra/aws/outputs.tf
+++ b/modules/infra/aws/outputs.tf
@@ -25,12 +25,8 @@ output "node_username" {
   value = var.ssh_username
 }
 
-output "ssh_key" {
-  value = var.create_ssh_key_pair ? tls_private_key.ssh_private_key[0].private_key_openssh : (var.ssh_key_pair_path != null ? file(pathexpand(var.ssh_key_pair_path)) : var.ssh_key)
-}
-
 output "ssh_key_path" {
-  value = var.create_ssh_key_pair ? local_file.private_key_pem[0].filename : var.ssh_key_pair_path
+  value = var.create_ssh_key_pair ? local_file.private_key_pem[0].filename : var.ssh_key_pair_path != null ? var.ssh_key_pair_path : null
 }
 
 output "ssh_key_pair_name" {

--- a/recipes/upstream/aws/k3s/main.tf
+++ b/recipes/upstream/aws/k3s/main.tf
@@ -47,7 +47,6 @@ module "k3s_additional_servers" {
   instance_disk_size      = var.instance_disk_size
   create_ssh_key_pair     = false
   ssh_key_pair_name       = module.k3s_first_server.ssh_key_pair_name
-  ssh_key_pair_path       = pathexpand(module.k3s_first_server.ssh_key_path)
   ssh_username            = var.ssh_username
   spot_instances          = var.spot_instances
   tag_begin               = 2
@@ -57,7 +56,6 @@ module "k3s_additional_servers" {
   subnet_id               = var.subnet_id
   user_data               = module.k3s_additional.k3s_server_user_data
 }
-
 
 module "k3s_workers" {
   source                  = "../../../../modules/infra/aws"

--- a/recipes/upstream/aws/k3s/terraform.tfvars.example
+++ b/recipes/upstream/aws/k3s/terraform.tfvars.example
@@ -42,7 +42,7 @@ worker_instance_count = 1
 ## -- (A) Create a new keypair in AWS
 create_ssh_key_pair = true
 ## -- Override the default (./${prefix}_ssh_private_key.pem) path where this SSH key is written
-# ssh_private_key_path = "/path/to/private/key.pem"
+# ssh_key_pair_path = "/path/to/private/key.pem"
 
 ## -- (B) Provide an existing keypair name in AWS to use for nodes, the matching private key file for this keypair also must be provided so RKE can SSH to the launched nodes
 # ssh_key_pair_name = "aws_keypair_name"

--- a/recipes/upstream/aws/rke/terraform.tfvars.example
+++ b/recipes/upstream/aws/rke/terraform.tfvars.example
@@ -37,7 +37,7 @@ instance_count = 1
 ## -- (A) Create a new keypair in AWS
 create_ssh_key_pair = true
 ## -- Override the default (./${prefix}_ssh_private_key.pem) path where this SSH key is written
-# ssh_private_key_path = "/path/to/private/key.pem"
+# ssh_key_pair_path = "/path/to/private/key.pem"
 
 ## -- (B) Provide an existing keypair name in AWS to use for nodes, the matching private key file for this keypair also must be provided so RKE can SSH to the launched nodes
 # ssh_key_pair_name = "aws_keypair_name"

--- a/recipes/upstream/aws/rke2/main.tf
+++ b/recipes/upstream/aws/rke2/main.tf
@@ -45,7 +45,6 @@ module "rke2_additional_servers" {
   instance_disk_size      = var.instance_disk_size
   create_ssh_key_pair     = false
   ssh_key_pair_name       = module.rke2_first_server.ssh_key_pair_name
-  ssh_key_pair_path       = module.rke2_first_server.ssh_key_path
   ssh_username            = var.ssh_username
   spot_instances          = var.spot_instances
   tag_begin               = 2

--- a/recipes/upstream/aws/rke2/terraform.tfvars.example
+++ b/recipes/upstream/aws/rke2/terraform.tfvars.example
@@ -40,7 +40,7 @@ instance_count = 1
 ## -- (A) Create a new keypair in AWS
 create_ssh_key_pair = true
 ## -- Override the default (./${prefix}_ssh_private_key.pem) path where this SSH key is written
-# ssh_private_key_path = "/path/to/private/key.pem"
+# ssh_key_pair_path = "/path/to/private/key.pem"
 
 ## -- (B) Provide an existing keypair name in AWS to use for nodes, the matching private key file for this keypair also must be provided so RKE can SSH to the launched nodes
 # ssh_key_pair_name = "aws_keypair_name"


### PR DESCRIPTION
- Update variable naming
- Removal of `ssh_key_pair_path` on additional servers, as only a keypair name is needed to launch the additional instances (created by the first instance and re-used)
- Update AWS module output to avoid invalid output when a key is re-used

```
│ Error: Invalid function argument
│ 
│   on ../../../../modules/infra/aws/outputs.tf line 29, in output "ssh_key":
│   29:   value = var.create_ssh_key_pair ? tls_private_key.ssh_private_key[0].private_key_openssh : (var.ssh_key_pair_path != null ? file(pathexpand(var.ssh_key_pair_path)) : var.ssh_key)
│     ├────────────────
│     │ while calling file(path)
│     │ var.ssh_key_pair_path is "..../recipes/upstream/aws/rke2/xxxx-ssh_private_key.pem"
│ 
│ Invalid value for "path" parameter: no file exists at "/..../recipes/upstream/aws/rke2/xxx-ssh_private_key.pem"; this function works only
```