### PR TITLE
Add ssh_key_pair_path for additional servers

### DIFF
--- a/recipes/upstream/aws/rke2/main.tf
+++ b/recipes/upstream/aws/rke2/main.tf
@@ -45,6 +45,7 @@ module "rke2_additional_servers" {
   instance_disk_size      = var.instance_disk_size
   create_ssh_key_pair     = false
   ssh_key_pair_name       = module.rke2_first_server.ssh_key_pair_name
+  ssh_key_pair_path       = var.ssh_key_pair_path
   ssh_username            = var.ssh_username
   spot_instances          = var.spot_instances
   tag_begin               = 2


### PR DESCRIPTION
Resolve an issue when using a pre-existing keypair/SSH private key and more than one instance.

Example, no SSH key was passed to handle the remote-exec provisioning check
```
timeout - last error: SSH authentication failed (ubuntu@1.2.3.4:22): ssh: handshake failed: ssh: unable to authenticate, attempted methods [none], no supported methods remain
```