### PR TITLE
Switch to SSM for AMI data source, update vars and docs

### DIFF
--- a/modules/infra/aws/ec2/data.tf
+++ b/modules/infra/aws/ec2/data.tf
@@ -1,31 +1,8 @@
-# TODO: Make the Ubuntu OS version configurable
 # TODO: Add support for ARM architecture
-data "aws_ami" "ubuntu" {
-  most_recent = true
-  owners      = ["099720109477"] # Canonical
-
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
+data "aws_ssm_parameter" "sles" {
+  name = "/aws/service/suse/sles-byos/${var.sles_version}/x86_64/latest"
 }
 
-data "aws_ami" "sles" {
-  most_recent = true
-  owners      = ["679593333241"] # SUSE
-
-  filter {
-    name   = "name"
-    values = ["suse-sles-15-sp6-byos-*-hvm-ssd-x86_64-*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
+data "aws_ssm_parameter" "ubuntu" {
+  name = "/aws/service/canonical/ubuntu/server/${var.ubuntu_version}/stable/current/amd64/hvm/ebs-gp2/ami-id"
 }

--- a/modules/infra/aws/ec2/docs.md
+++ b/modules/infra/aws/ec2/docs.md
@@ -25,8 +25,8 @@ No modules.
 | [aws_security_group.sg_allowall](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [local_file.private_key_pem](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [tls_private_key.ssh_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [aws_ami.sles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
-| [aws_ami.ubuntu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_ssm_parameter.sles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.ubuntu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 
 ## Inputs
 
@@ -46,6 +46,7 @@ No modules.
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for all EC2 instances | `string` | `"t3.medium"` | no |
 | <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Use SLES or Ubuntu images when launching instances (sles or ubuntu) | `string` | `"sles"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `"rancher-terraform"` | no |
+| <a name="input_sles_version"></a> [sles\_version](#input\_sles\_version) | Version of SLES to use for instances (ex: 15-sp6) | `string` | `"15-sp6"` | no |
 | <a name="input_spot_instances"></a> [spot\_instances](#input\_spot\_instances) | Use spot instances | `bool` | `false` | no |
 | <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | Contents of the private key to connect to the instances. | `string` | `null` | no |
 | <a name="input_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#input\_ssh\_key\_pair\_name) | Specify the SSH key name to use (that's already present in AWS) | `string` | `null` | no |
@@ -55,6 +56,7 @@ No modules.
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `string` | `null` | no |
 | <a name="input_tag_begin"></a> [tag\_begin](#input\_tag\_begin) | When module is being called mode than once, begin tagging from this number | `number` | `1` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | User-provided tags for the resources | `map(string)` | `{}` | no |
+| <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Version of Ubuntu to use for instances (ex: 22.04) | `string` | `"22.04"` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | User data content for EC2 instance(s) | `any` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to create the instance(s) in | `string` | `null` | no |
 

--- a/modules/infra/aws/ec2/main.tf
+++ b/modules/infra/aws/ec2/main.tf
@@ -82,11 +82,10 @@ resource "aws_security_group" "sg_allowall" {
 }
 
 resource "aws_instance" "instance" {
-  count         = var.instance_count
-  ami           = var.instance_ami != null ? var.instance_ami : var.os_type == "sles" ? data.aws_ami.sles.id : data.aws_ami.ubuntu.id
-  instance_type = var.instance_type
-  subnet_id     = var.subnet_id
-
+  count                  = var.instance_count
+  ami                    = var.instance_ami != null ? var.instance_ami : var.os_type == "sles" ? data.aws_ssm_parameter.sles.insecure_value : data.aws_ssm_parameter.ubuntu.insecure_value
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
   key_name               = var.create_ssh_key_pair ? aws_key_pair.key_pair[0].key_name : var.ssh_key_pair_name
   vpc_security_group_ids = [var.create_security_group ? aws_security_group.sg_allowall[0].id : var.instance_security_group]
   user_data              = var.user_data

--- a/modules/infra/aws/ec2/variables.tf
+++ b/modules/infra/aws/ec2/variables.tf
@@ -80,7 +80,7 @@ variable "instance_disk_size" {
 variable "instance_count" {
   type        = number
   description = "Number of EC2 instances to create"
-  default     = 1
+  default     = 0
   nullable    = false
 }
 
@@ -98,6 +98,16 @@ variable "os_type" {
     condition     = contains(["sles", "ubuntu"], var.os_type)
     error_message = "The operating system type must be 'sles' or 'ubuntu'."
   }
+}
+
+variable "sles_version" {
+  description = "Version of SLES to use for instances (ex: 15-sp6)"
+  default     = "15-sp6"
+}
+
+variable "ubuntu_version" {
+  description = "Version of Ubuntu to use for instances (ex: 22.04)"
+  default     = "22.04"
 }
 
 variable "vpc_id" {

--- a/recipes/rke/split-roles/aws/docs.md
+++ b/recipes/rke/split-roles/aws/docs.md
@@ -45,12 +45,14 @@ No resources.
 | <a name="input_master_nodes_instance_type"></a> [master\_nodes\_instance\_type](#input\_master\_nodes\_instance\_type) | Instance type used for all master nodes | `string` | `"t3.medium"` | no |
 | <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Use SLES or Ubuntu images when launching instances (sles or ubuntu) | `string` | `null` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | n/a | yes |
+| <a name="input_sles_version"></a> [sles\_version](#input\_sles\_version) | Version of SLES to use for instances (ex: 15-sp6) | `string` | `"15-sp6"` | no |
 | <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | Contents of the private key to connect to the instances. | `string` | `null` | no |
 | <a name="input_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#input\_ssh\_key\_pair\_name) | Specify the SSH key name to use (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_key_pair_path"></a> [ssh\_key\_pair\_path](#input\_ssh\_key\_pair\_path) | Path to the SSH private key used as the key pair (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username used for SSH with sudo access, must align with the AMI in use | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | User-provided tags for the resources | `map(string)` | `{}` | no |
+| <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Version of Ubuntu to use for instances (ex: 22.04) | `string` | `"22.04"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to create the instance(s) in | `string` | `null` | no |
 | <a name="input_vpc_zone"></a> [vpc\_zone](#input\_vpc\_zone) | VPC zone | `string` | `null` | no |
 | <a name="input_worker_nodes_count"></a> [worker\_nodes\_count](#input\_worker\_nodes\_count) | Number of worker nodes to create | `number` | `1` | no |

--- a/recipes/rke/split-roles/aws/main.tf
+++ b/recipes/rke/split-roles/aws/main.tf
@@ -11,6 +11,8 @@ module "master_nodes" {
   instance_disk_size      = var.master_nodes_instance_disk_size
   instance_ami            = var.instance_ami
   os_type                 = var.os_type
+  sles_version            = var.sles_version
+  ubuntu_version          = var.ubuntu_version
   create_ssh_key_pair     = var.create_ssh_key_pair
   ssh_key_pair_name       = var.ssh_key_pair_name
   ssh_key_pair_path       = var.ssh_key_pair_path
@@ -43,6 +45,8 @@ module "worker_nodes" {
   instance_disk_size      = var.worker_nodes_instance_disk_size
   instance_ami            = var.instance_ami
   os_type                 = var.os_type
+  sles_version            = var.sles_version
+  ubuntu_version          = var.ubuntu_version
   create_ssh_key_pair     = var.create_ssh_key_pair
   ssh_key_pair_name       = var.ssh_key_pair_name
   ssh_key_pair_path       = var.ssh_key_pair_path

--- a/recipes/rke/split-roles/aws/terraform.tfvars.example
+++ b/recipes/rke/split-roles/aws/terraform.tfvars.example
@@ -37,6 +37,9 @@ worker_nodes_count = 1
 
 ### -- Use SLES or Ubuntu images when launching instances (sles or ubuntu)
 # os_type = "sles"
+# sles_version = "15-sp6"
+# ubuntu_version = "22.04"
+
 ## - SSH username (must match the SSH user for the AMI used)
 # ssh_username = "ec2-user"
 ## - Custom AMI to launch instances with

--- a/recipes/rke/split-roles/aws/variables.tf
+++ b/recipes/rke/split-roles/aws/variables.tf
@@ -152,6 +152,16 @@ variable "os_type" {
   default     = null
 }
 
+variable "sles_version" {
+  description = "Version of SLES to use for instances (ex: 15-sp6)"
+  default     = "15-sp6"
+}
+
+variable "ubuntu_version" {
+  description = "Version of Ubuntu to use for instances (ex: 22.04)"
+  default     = "22.04"
+}
+
 variable "master_nodes_instance_type" {
   type        = string
   description = "Instance type used for all master nodes"

--- a/recipes/standalone/aws/rke/docs.md
+++ b/recipes/standalone/aws/rke/docs.md
@@ -39,11 +39,13 @@ No resources.
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version to use for the RKE cluster | `string` | `null` | no |
 | <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Use SLES or Ubuntu images when launching instances (sles or ubuntu) | `string` | `null` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `null` | no |
+| <a name="input_sles_version"></a> [sles\_version](#input\_sles\_version) | Version of SLES to use for instances (ex: 15-sp6) | `string` | `"15-sp6"` | no |
 | <a name="input_spot_instances"></a> [spot\_instances](#input\_spot\_instances) | Use spot instances | `bool` | `null` | no |
 | <a name="input_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#input\_ssh\_key\_pair\_name) | Specify the SSH key name to use (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_key_pair_path"></a> [ssh\_key\_pair\_path](#input\_ssh\_key\_pair\_path) | Path to the SSH private key used as the key pair (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username used for SSH with sudo access, must align with the AMI in use | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `string` | `null` | no |
+| <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Version of Ubuntu to use for instances (ex: 22.04) | `string` | `"22.04"` | no |
 
 ## Outputs
 

--- a/recipes/standalone/aws/rke/main.tf
+++ b/recipes/standalone/aws/rke/main.tf
@@ -10,6 +10,8 @@ module "cluster-nodes" {
   instance_disk_size      = var.instance_disk_size
   instance_ami            = var.instance_ami
   os_type                 = var.os_type
+  sles_version            = var.sles_version
+  ubuntu_version          = var.ubuntu_version
   create_ssh_key_pair     = var.create_ssh_key_pair
   ssh_key_pair_name       = var.ssh_key_pair_name
   ssh_key_pair_path       = var.ssh_key_pair_path

--- a/recipes/standalone/aws/rke/terraform.tfvars.example
+++ b/recipes/standalone/aws/rke/terraform.tfvars.example
@@ -35,6 +35,9 @@ instance_count = 1
 
 ### -- Use SLES or Ubuntu images when launching instances (sles or ubuntu)
 # os_type = "sles"
+# sles_version = "15-sp6"
+# ubuntu_version = "22.04"
+
 ## - SSH username (must match the SSH user for the AMI used)
 # ssh_username = "ec2-user"
 ## - Custom AMI to launch instances with

--- a/recipes/standalone/aws/rke/variables.tf
+++ b/recipes/standalone/aws/rke/variables.tf
@@ -152,6 +152,16 @@ variable "os_type" {
   default     = null
 }
 
+variable "sles_version" {
+  description = "Version of SLES to use for instances (ex: 15-sp6)"
+  default     = "15-sp6"
+}
+
+variable "ubuntu_version" {
+  description = "Version of Ubuntu to use for instances (ex: 22.04)"
+  default     = "22.04"
+}
+
 variable "subnet_id" {
   type        = string
   description = "VPC Subnet ID to create the instance(s) in"

--- a/recipes/upstream/aws/k3s/docs.md
+++ b/recipes/upstream/aws/k3s/docs.md
@@ -63,11 +63,13 @@
 | <a name="input_rancher_replicas"></a> [rancher\_replicas](#input\_rancher\_replicas) | Value for replicas when installing the Rancher helm chart | `number` | `3` | no |
 | <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Rancher version to install | `string` | `null` | no |
 | <a name="input_server_instance_count"></a> [server\_instance\_count](#input\_server\_instance\_count) | Number of server EC2 instances to create | `number` | `null` | no |
+| <a name="input_sles_version"></a> [sles\_version](#input\_sles\_version) | Version of SLES to use for instances (ex: 15-sp6) | `string` | `"15-sp6"` | no |
 | <a name="input_spot_instances"></a> [spot\_instances](#input\_spot\_instances) | Use spot instances | `bool` | `null` | no |
 | <a name="input_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#input\_ssh\_key\_pair\_name) | Specify the SSH key name to use (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_key_pair_path"></a> [ssh\_key\_pair\_path](#input\_ssh\_key\_pair\_path) | Path to the SSH private key used as the key pair (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username used for SSH with sudo access, must align with the AMI in use | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `string` | `null` | no |
+| <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Version of Ubuntu to use for instances (ex: 22.04) | `string` | `"22.04"` | no |
 | <a name="input_wait"></a> [wait](#input\_wait) | An optional wait before installing the Rancher helm chart | `string` | `"20s"` | no |
 | <a name="input_worker_instance_count"></a> [worker\_instance\_count](#input\_worker\_instance\_count) | Number of worker EC2 instances to create | `number` | `null` | no |
 

--- a/recipes/upstream/aws/k3s/main.tf
+++ b/recipes/upstream/aws/k3s/main.tf
@@ -21,6 +21,8 @@ module "k3s_first_server" {
   instance_disk_size      = var.instance_disk_size
   instance_ami            = var.instance_ami
   os_type                 = var.os_type
+  sles_version            = var.sles_version
+  ubuntu_version          = var.ubuntu_version
   create_ssh_key_pair     = var.create_ssh_key_pair
   ssh_key_pair_name       = var.ssh_key_pair_name
   ssh_key_pair_path       = var.ssh_key_pair_path
@@ -52,6 +54,8 @@ module "k3s_additional_servers" {
   instance_disk_size      = var.instance_disk_size
   instance_ami            = var.instance_ami
   os_type                 = var.os_type
+  sles_version            = var.sles_version
+  ubuntu_version          = var.ubuntu_version
   create_ssh_key_pair     = false
   ssh_key_pair_name       = module.k3s_first_server.ssh_key_pair_name
   ssh_key_pair_path       = module.k3s_first_server.ssh_key_path
@@ -75,6 +79,8 @@ module "k3s_workers" {
   instance_disk_size      = var.instance_disk_size
   instance_ami            = var.instance_ami
   os_type                 = var.os_type
+  sles_version            = var.sles_version
+  ubuntu_version          = var.ubuntu_version
   create_ssh_key_pair     = false
   ssh_key_pair_name       = module.k3s_first_server.ssh_key_pair_name
   ssh_key_pair_path       = module.k3s_first_server.ssh_key_path

--- a/recipes/upstream/aws/k3s/terraform.tfvars.example
+++ b/recipes/upstream/aws/k3s/terraform.tfvars.example
@@ -40,6 +40,9 @@ worker_instance_count = 1
 
 ### -- Use SLES or Ubuntu images when launching instances (sles or ubuntu)
 # os_type = "sles"
+# sles_version = "15-sp6"
+# ubuntu_version = "22.04"
+
 ## - SSH username (must match the SSH user for the AMI used)
 # ssh_username = "ec2-user"
 ## - Custom AMI to launch instances with

--- a/recipes/upstream/aws/k3s/variables.tf
+++ b/recipes/upstream/aws/k3s/variables.tf
@@ -227,6 +227,16 @@ variable "os_type" {
   default     = "sles"
 }
 
+variable "sles_version" {
+  description = "Version of SLES to use for instances (ex: 15-sp6)"
+  default     = "15-sp6"
+}
+
+variable "ubuntu_version" {
+  description = "Version of Ubuntu to use for instances (ex: 22.04)"
+  default     = "22.04"
+}
+
 variable "subnet_id" {
   type        = string
   description = "VPC Subnet ID to create the instance(s) in"

--- a/recipes/upstream/aws/rke/docs.md
+++ b/recipes/upstream/aws/rke/docs.md
@@ -49,11 +49,13 @@ No resources.
 | <a name="input_rancher_password"></a> [rancher\_password](#input\_rancher\_password) | Password for the Rancher admin account (min 12 characters) | `string` | `null` | no |
 | <a name="input_rancher_replicas"></a> [rancher\_replicas](#input\_rancher\_replicas) | Value for replicas when installing the Rancher helm chart | `number` | `3` | no |
 | <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Rancher version to install | `string` | `null` | no |
+| <a name="input_sles_version"></a> [sles\_version](#input\_sles\_version) | Version of SLES to use for instances (ex: 15-sp6) | `string` | `"15-sp6"` | no |
 | <a name="input_spot_instances"></a> [spot\_instances](#input\_spot\_instances) | Use spot instances | `bool` | `null` | no |
 | <a name="input_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#input\_ssh\_key\_pair\_name) | Specify the SSH key name to use (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_key_pair_path"></a> [ssh\_key\_pair\_path](#input\_ssh\_key\_pair\_path) | Path to the SSH private key used as the key pair (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username used for SSH with sudo access, must align with the AMI in use | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `string` | `null` | no |
+| <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Version of Ubuntu to use for instances (ex: 22.04) | `string` | `"22.04"` | no |
 | <a name="input_wait"></a> [wait](#input\_wait) | An optional wait before installing the Rancher helm chart | `string` | `"20s"` | no |
 
 ## Outputs

--- a/recipes/upstream/aws/rke/main.tf
+++ b/recipes/upstream/aws/rke/main.tf
@@ -12,6 +12,8 @@ module "rke" {
   instance_disk_size = var.instance_disk_size
   instance_ami       = var.instance_ami
   os_type            = var.os_type
+  sles_version       = var.sles_version
+  ubuntu_version     = var.ubuntu_version
   spot_instances     = var.spot_instances
   install_docker     = var.install_docker
   docker_version     = var.docker_version

--- a/recipes/upstream/aws/rke/terraform.tfvars.example
+++ b/recipes/upstream/aws/rke/terraform.tfvars.example
@@ -38,6 +38,9 @@ instance_count = 1
 
 ### -- Use SLES or Ubuntu images when launching instances (sles or ubuntu)
 # os_type = "sles"
+# sles_version = "15-sp6"
+# ubuntu_version = "22.04"
+
 ## - SSH username (must match the SSH user for the AMI used)
 # ssh_username = "ec2-user"
 ## - Custom AMI to launch instances with

--- a/recipes/upstream/aws/rke/variables.tf
+++ b/recipes/upstream/aws/rke/variables.tf
@@ -186,6 +186,16 @@ variable "os_type" {
   default     = "sles"
 }
 
+variable "sles_version" {
+  description = "Version of SLES to use for instances (ex: 15-sp6)"
+  default     = "15-sp6"
+}
+
+variable "ubuntu_version" {
+  description = "Version of Ubuntu to use for instances (ex: 22.04)"
+  default     = "22.04"
+}
+
 variable "subnet_id" {
   type        = string
   description = "VPC Subnet ID to create the instance(s) in"

--- a/recipes/upstream/aws/rke2/docs.md
+++ b/recipes/upstream/aws/rke2/docs.md
@@ -61,11 +61,13 @@
 | <a name="input_rke2_config"></a> [rke2\_config](#input\_rke2\_config) | Additional RKE2 configuration to add to the config.yaml file | `any` | `null` | no |
 | <a name="input_rke2_token"></a> [rke2\_token](#input\_rke2\_token) | Token to use when configuring RKE2 nodes | `any` | `null` | no |
 | <a name="input_rke2_version"></a> [rke2\_version](#input\_rke2\_version) | Kubernetes version to use for the RKE2 cluster | `string` | `null` | no |
+| <a name="input_sles_version"></a> [sles\_version](#input\_sles\_version) | Version of SLES to use for instances (ex: 15-sp6) | `string` | `"15-sp6"` | no |
 | <a name="input_spot_instances"></a> [spot\_instances](#input\_spot\_instances) | Use spot instances | `bool` | `null` | no |
 | <a name="input_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#input\_ssh\_key\_pair\_name) | Specify the SSH key name to use (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_key_pair_path"></a> [ssh\_key\_pair\_path](#input\_ssh\_key\_pair\_path) | Path to the SSH private key used as the key pair (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username used for SSH with sudo access, must align with the AMI in use | `string` | `null` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `string` | `null` | no |
+| <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Version of Ubuntu to use for instances (ex: 22.04) | `string` | `"22.04"` | no |
 | <a name="input_wait"></a> [wait](#input\_wait) | An optional wait before installing the Rancher helm chart | `string` | `"20s"` | no |
 
 ## Outputs

--- a/recipes/upstream/aws/rke2/main.tf
+++ b/recipes/upstream/aws/rke2/main.tf
@@ -20,6 +20,8 @@ module "rke2_first_server" {
   instance_disk_size      = var.instance_disk_size
   instance_ami            = var.instance_ami
   os_type                 = var.os_type
+  sles_version            = var.sles_version
+  ubuntu_version          = var.ubuntu_version
   create_ssh_key_pair     = var.create_ssh_key_pair
   ssh_key_pair_name       = var.ssh_key_pair_name
   ssh_key_pair_path       = var.ssh_key_pair_path
@@ -48,6 +50,8 @@ module "rke2_additional_servers" {
   instance_disk_size      = var.instance_disk_size
   instance_ami            = var.instance_ami
   os_type                 = var.os_type
+  sles_version            = var.sles_version
+  ubuntu_version          = var.ubuntu_version
   create_ssh_key_pair     = false
   ssh_key_pair_name       = module.rke2_first_server.ssh_key_pair_name
   ssh_key_pair_path       = module.rke2_first_server.ssh_key_path

--- a/recipes/upstream/aws/rke2/terraform.tfvars.example
+++ b/recipes/upstream/aws/rke2/terraform.tfvars.example
@@ -38,6 +38,9 @@ instance_count = 1
 
 ### -- Use SLES or Ubuntu images when launching instances (sles or ubuntu)
 # os_type = "sles"
+# sles_version = "15-sp6"
+# ubuntu_version = "22.04"
+
 ## - SSH username (must match the SSH user for the AMI used)
 # ssh_username = "ec2-user"
 ## - Custom AMI to launch instances with

--- a/recipes/upstream/aws/rke2/variables.tf
+++ b/recipes/upstream/aws/rke2/variables.tf
@@ -215,6 +215,16 @@ variable "os_type" {
   default     = "sles"
 }
 
+variable "sles_version" {
+  description = "Version of SLES to use for instances (ex: 15-sp6)"
+  default     = "15-sp6"
+}
+
+variable "ubuntu_version" {
+  description = "Version of Ubuntu to use for instances (ex: 22.04)"
+  default     = "22.04"
+}
+
 variable "subnet_id" {
   type        = string
   description = "VPC Subnet ID to create the instance(s) in"


### PR DESCRIPTION
- Switch to SSM for consistent source of AMI IDs in every region
- Update variables and tfvars examples
- Update docs