### PR TITLE
Add AWS VPC initial module, add support for rke2/k3s

### DIFF
--- a/modules/infra/aws/ec2/data.tf
+++ b/modules/infra/aws/ec2/data.tf
@@ -13,14 +13,14 @@ data "aws_security_group" "sg" {
 }
 
 data "aws_vpc" "default_vpc" {
-  count = var.create_vpc != true ? 1 : 0
+  count   = var.create_vpc != true ? 1 : 0
   default = true
 }
 
 data "aws_subnets" "default_subnets" {
   count = var.create_vpc != true ? 1 : 0
   filter {
-    name = "vpc-id"
+    name   = "vpc-id"
     values = [data.aws_vpc.default_vpc[0].id]
   }
 }

--- a/modules/infra/aws/ec2/data.tf
+++ b/modules/infra/aws/ec2/data.tf
@@ -6,3 +6,21 @@ data "aws_ssm_parameter" "sles" {
 data "aws_ssm_parameter" "ubuntu" {
   name = "/aws/service/canonical/ubuntu/server/${var.ubuntu_version}/stable/current/amd64/hvm/ebs-gp2/ami-id"
 }
+
+data "aws_security_group" "sg" {
+  count = var.create_security_group ? 0 : 1
+  id    = var.instance_security_group
+}
+
+data "aws_vpc" "default_vpc" {
+  count = var.create_vpc != true ? 1 : 0
+  default = true
+}
+
+data "aws_subnets" "default_subnets" {
+  count = var.create_vpc != true ? 1 : 0
+  filter {
+    name = "vpc-id"
+    values = [data.aws_vpc.default_vpc[0].id]
+  }
+}

--- a/modules/infra/aws/ec2/docs.md
+++ b/modules/infra/aws/ec2/docs.md
@@ -2,19 +2,23 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.13.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.46 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.13.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.46 |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_vpc"></a> [aws\_vpc](#module\_aws\_vpc) | ../vpc | n/a |
 
 ## Resources
 
@@ -24,9 +28,13 @@ No modules.
 | [aws_key_pair.key_pair](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_security_group.sg_allowall](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [local_file.private_key_pem](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [random_shuffle.subnet](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/shuffle) | resource |
 | [tls_private_key.ssh_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [aws_security_group.sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
 | [aws_ssm_parameter.sles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
 | [aws_ssm_parameter.ubuntu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_subnets.default_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.default_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
@@ -36,16 +44,19 @@ No modules.
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region used for all resources | `string` | `"us-east-1"` | no |
 | <a name="input_aws_secret_key"></a> [aws\_secret\_key](#input\_aws\_secret\_key) | AWS secret key used to create AWS infrastructure | `string` | `null` | no |
 | <a name="input_bastion_host"></a> [bastion\_host](#input\_bastion\_host) | Bastion host configuration to access the instances | <pre>object({<br>    address      = string<br>    user         = string<br>    ssh_key      = string<br>    ssh_key_path = string<br>  })</pre> | `null` | no |
-| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Should create the security group associated with the instance(s) | `bool` | `true` | no |
+| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Create the security group attached to the instance(s) | `bool` | `true` | no |
 | <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `true` | no |
+| <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Create a VPC | `bool` | `false` | no |
 | <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | Specify IAM Instance Profile to assign to the instances/nodes | `string` | `null` | no |
 | <a name="input_instance_ami"></a> [instance\_ami](#input\_instance\_ami) | Override the default SLES or Ubuntu AMI | `string` | `null` | no |
-| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of EC2 instances to create | `number` | `1` | no |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of EC2 instances to create | `number` | `0` | no |
 | <a name="input_instance_disk_size"></a> [instance\_disk\_size](#input\_instance\_disk\_size) | Specify root disk size (GB) | `string` | `"80"` | no |
-| <a name="input_instance_security_group"></a> [instance\_security\_group](#input\_instance\_security\_group) | Provide a pre-existing security group ID | `string` | `null` | no |
+| <a name="input_instance_security_group"></a> [instance\_security\_group](#input\_instance\_security\_group) | Provide a pre-existing security group ID to attach to the instance(s) | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for all EC2 instances | `string` | `"t3.medium"` | no |
 | <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Use SLES or Ubuntu images when launching instances (sles or ubuntu) | `string` | `"sles"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `"rancher-terraform"` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Create Public subnets for VPC | `any` | `null` | no |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | Create Public subnets for VPC | `bool` | `true` | no |
 | <a name="input_sles_version"></a> [sles\_version](#input\_sles\_version) | Version of SLES to use for instances (ex: 15-sp6) | `string` | `"15-sp6"` | no |
 | <a name="input_spot_instances"></a> [spot\_instances](#input\_spot\_instances) | Use spot instances | `bool` | `false` | no |
 | <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | Contents of the private key to connect to the instances. | `string` | `null` | no |
@@ -53,12 +64,12 @@ No modules.
 | <a name="input_ssh_key_pair_path"></a> [ssh\_key\_pair\_path](#input\_ssh\_key\_pair\_path) | Path to the SSH private key used as the key pair (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_private_key_path"></a> [ssh\_private\_key\_path](#input\_ssh\_private\_key\_path) | Path to write the generated SSH private key | `string` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username used for SSH with sudo access | `string` | `null` | no |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `string` | `null` | no |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `any` | `null` | no |
 | <a name="input_tag_begin"></a> [tag\_begin](#input\_tag\_begin) | When module is being called mode than once, begin tagging from this number | `number` | `1` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | User-provided tags for the resources | `map(string)` | `{}` | no |
 | <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Version of Ubuntu to use for instances (ex: 22.04) | `string` | `"22.04"` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | User data content for EC2 instance(s) | `any` | `null` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to create the instance(s) in | `string` | `null` | no |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR for AWS VPC | `string` | `"10.0.0.0/16"` | no |
 
 ## Outputs
 
@@ -69,6 +80,9 @@ No modules.
 | <a name="output_instances_private_ip"></a> [instances\_private\_ip](#output\_instances\_private\_ip) | n/a |
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
 | <a name="output_node_username"></a> [node\_username](#output\_node\_username) | n/a |
+| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | n/a |
+| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | n/a |
 | <a name="output_sg-id"></a> [sg-id](#output\_sg-id) | n/a |
 | <a name="output_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#output\_ssh\_key\_pair\_name) | n/a |
 | <a name="output_ssh_key_path"></a> [ssh\_key\_path](#output\_ssh\_key\_path) | n/a |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |

--- a/modules/infra/aws/ec2/main.tf
+++ b/modules/infra/aws/ec2/main.tf
@@ -1,6 +1,6 @@
 locals {
   new_key_pair_path = var.ssh_private_key_path != null ? var.ssh_private_key_path : "${path.cwd}/${var.prefix}-ssh_private_key.pem"
-  existing_subnet = var.subnet_id != null ? var.subnet_id : data.aws_subnets.default_subnets[0].ids 
+  existing_subnet   = var.subnet_id != null ? var.subnet_id : data.aws_subnets.default_subnets[0].ids
 }
 
 resource "tls_private_key" "ssh_private_key" {

--- a/modules/infra/aws/ec2/main.tf
+++ b/modules/infra/aws/ec2/main.tf
@@ -1,6 +1,6 @@
 locals {
   new_key_pair_path = var.ssh_private_key_path != null ? var.ssh_private_key_path : "${path.cwd}/${var.prefix}-ssh_private_key.pem"
-  existing_subnet   = var.subnet_id != null ? var.subnet_id : data.aws_subnets.default_subnets[0].ids
+  existing_subnet   = var.subnet_id != null ? var.subnet_id : try(data.aws_subnets.default_subnets[0].ids, [])
 }
 
 resource "tls_private_key" "ssh_private_key" {
@@ -24,7 +24,7 @@ resource "aws_key_pair" "key_pair" {
 module "aws_vpc" {
   count           = var.create_vpc == true ? 1 : 0
   source          = "../vpc"
-  prefix          = var.prefix
+  prefix          = trimsuffix(var.prefix, "-cp")
   vpc_cidr        = var.vpc_cidr
   public_subnets  = var.public_subnets
   private_subnets = var.private_subnets

--- a/modules/infra/aws/ec2/outputs.tf
+++ b/modules/infra/aws/ec2/outputs.tf
@@ -33,6 +33,18 @@ output "ssh_key_pair_name" {
   value = var.create_ssh_key_pair ? aws_key_pair.key_pair[0].key_name : var.ssh_key_pair_name
 }
 
+output "public_subnets" {
+  value = var.create_vpc == true ? module.aws_vpc[0].public_subnets : tolist(local.existing_subnet)
+}
+
+output "private_subnets" {
+  value = var.create_vpc == true ? module.aws_vpc[0].private_subnets : null
+}
+
+output "vpc_id" {
+  value = var.create_vpc == true ? module.aws_vpc[0].vpc_id : null
+}
+
 output "sg-id" {
   value = var.create_security_group ? aws_security_group.sg_allowall[0].id : var.instance_security_group
 }

--- a/modules/infra/aws/ec2/variables.tf
+++ b/modules/infra/aws/ec2/variables.tf
@@ -209,10 +209,6 @@ variable "iam_instance_profile" {
 variable "create_vpc" {
   description = "Create a VPC"
   default     = false
-  # validation {
-  #   condition     = var.create_vpc && var.instance_security_group == null
-  #   error_message = "If creating a VPC the SG must be created"
-  # }
 }
 
 variable "vpc_cidr" {

--- a/modules/infra/aws/ec2/variables.tf
+++ b/modules/infra/aws/ec2/variables.tf
@@ -110,14 +110,8 @@ variable "ubuntu_version" {
   default     = "22.04"
 }
 
-variable "vpc_id" {
-  type        = string
-  description = "VPC ID to create the instance(s) in"
-  default     = null
-}
-
 variable "subnet_id" {
-  type        = string
+  type        = any
   description = "VPC Subnet ID to create the instance(s) in"
   default     = null
 }
@@ -159,16 +153,18 @@ variable "ssh_private_key_path" {
 
 variable "create_security_group" {
   type        = bool
-  description = "Should create the security group associated with the instance(s)"
+  description = "Create the security group attached to the instance(s)"
   default     = true
-  nullable    = false
 }
 
-# TODO: Add a check based on above value
 variable "instance_security_group" {
   type        = string
-  description = "Provide a pre-existing security group ID"
+  description = "Provide a pre-existing security group ID to attach to the instance(s)"
   default     = null
+  validation {
+    condition     = var.create_security_group && var.instance_security_group == null || !var.create_security_group && var.instance_security_group != null
+    error_message = "Both create_security_group and instance_security_group can't be set, choose either option. If creating a VPC the SG must be created"
+  }
 }
 
 variable "ssh_username" {
@@ -207,6 +203,30 @@ variable "bastion_host" {
 variable "iam_instance_profile" {
   type        = string
   description = "Specify IAM Instance Profile to assign to the instances/nodes"
+  default     = null
+}
+
+variable "create_vpc" {
+  description = "Create a VPC"
+  default     = false
+  # validation {
+  #   condition     = var.create_vpc && var.instance_security_group == null
+  #   error_message = "If creating a VPC the SG must be created"
+  # }
+}
+
+variable "vpc_cidr" {
+  description = "CIDR for AWS VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "Create Public subnets for VPC"
+  default     = true
+}
+
+variable "private_subnets" {
+  description = "Create Public subnets for VPC"
   default     = null
 }
 

--- a/modules/infra/aws/ec2/versions.tf
+++ b/modules/infra/aws/ec2/versions.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 1.10"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.13.1"
+      version = ">= 5.46"
     }
   }
 }

--- a/modules/infra/aws/vpc/data.tf
+++ b/modules/infra/aws/vpc/data.tf
@@ -1,0 +1,2 @@
+data "aws_availability_zones" "azs" {
+}

--- a/modules/infra/aws/vpc/docs.md
+++ b/modules/infra/aws/vpc/docs.md
@@ -1,0 +1,31 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_access_key"></a> [aws\_access\_key](#input\_aws\_access\_key) | AWS access key used to create infrastructure | `string` | `null` | no |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region used for all resources | `string` | `"us-east-1"` | no |
+| <a name="input_aws_secret_key"></a> [aws\_secret\_key](#input\_aws\_secret\_key) | AWS secret key used to create AWS infrastructure | `string` | `null` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `"rancher-terraform"` | no |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR for AWS VPC | `string` | `"10.0.0.0/16"` | no |
+
+## Outputs
+
+No outputs.

--- a/modules/infra/aws/vpc/docs.md
+++ b/modules/infra/aws/vpc/docs.md
@@ -4,7 +4,9 @@ No requirements.
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
@@ -14,7 +16,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_availability_zones.azs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 
 ## Inputs
 
@@ -24,8 +28,15 @@ No resources.
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region used for all resources | `string` | `"us-east-1"` | no |
 | <a name="input_aws_secret_key"></a> [aws\_secret\_key](#input\_aws\_secret\_key) | AWS secret key used to create AWS infrastructure | `string` | `null` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `"rancher-terraform"` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Create Public subnets for VPC | `any` | `null` | no |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | Create Public subnets for VPC | `bool` | `true` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | User-provided tags for the resources | `map(string)` | `{}` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR for AWS VPC | `string` | `"10.0.0.0/16"` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | n/a |
+| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | n/a |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |

--- a/modules/infra/aws/vpc/main.tf
+++ b/modules/infra/aws/vpc/main.tf
@@ -1,0 +1,44 @@
+locals {
+  availability_zones = slice(data.aws_availability_zones.azs.names, 0, 3)
+  private_subnets    = [for i in range(length(local.availability_zones)) : cidrsubnet(var.vpc_cidr, 8, i + 100)]
+  public_subnets     = [for i in range(length(local.availability_zones)) : cidrsubnet(var.vpc_cidr, 8, i + 200)]
+}
+
+module "vpc" {
+  count  = var.vpc_cidr != null && var.public_subnets != null ? 1 : 0
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "${var.prefix}-vpc"
+  cidr = var.vpc_cidr
+
+  azs                     = local.availability_zones
+  private_subnets         = local.private_subnets
+  public_subnets          = local.public_subnets
+  map_public_ip_on_launch = true
+
+  enable_nat_gateway     = var.private_subnets == null ? false : true
+  single_nat_gateway     = var.private_subnets == null ? false : true
+  one_nat_gateway_per_az = var.private_subnets == null ? false : false
+
+  private_subnet_tags = merge(
+    {
+      Name    = "${var.prefix}-private-subnet"
+      Creator = var.prefix
+    },
+    var.tags
+  )
+  public_subnet_tags = merge(
+    {
+      Name    = "${var.prefix}-public-subnet"
+      Creator = var.prefix
+    },
+    var.tags
+  )
+  tags = merge(
+    {
+      Name    = "${var.prefix}-vpc"
+      Creator = var.prefix
+    },
+    var.tags
+  )
+}

--- a/modules/infra/aws/vpc/outputs.tf
+++ b/modules/infra/aws/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "public_subnets" {
+  value = module.vpc[0].public_subnets
+}
+
+output "private_subnets" {
+  value = module.vpc[0].private_subnets
+}
+
+output "vpc_id" {
+  value = module.vpc[0].vpc_id
+}

--- a/modules/infra/aws/vpc/variables.tf
+++ b/modules/infra/aws/vpc/variables.tf
@@ -1,0 +1,79 @@
+variable "aws_access_key" {
+  type        = string
+  description = "AWS access key used to create infrastructure"
+  default     = null
+}
+
+variable "aws_secret_key" {
+  type        = string
+  description = "AWS secret key used to create AWS infrastructure"
+  default     = null
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region used for all resources"
+  default     = "us-east-1"
+
+  validation {
+    condition = contains([
+      "us-east-2",
+      "us-east-1",
+      "us-west-1",
+      "us-west-2",
+      "af-south-1",
+      "ap-east-1",
+      "ap-south-2",
+      "ap-southeast-3",
+      "ap-southeast-4",
+      "ap-south-1",
+      "ap-northeast-3",
+      "ap-northeast-2",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ap-northeast-1",
+      "ca-central-1",
+      "ca-west-1",
+      "eu-central-1",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-south-1",
+      "eu-west-3",
+      "eu-south-2",
+      "eu-north-1",
+      "eu-central-2",
+      "il-central-1",
+      "me-south-1",
+      "me-central-1",
+      "sa-east-1",
+    ], var.aws_region)
+    error_message = "Invalid Region specified!"
+  }
+}
+
+variable "prefix" {
+  type        = string
+  description = "Prefix added to names of all resources"
+  default     = "rancher-terraform"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR for AWS VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "Create Public subnets for VPC"
+  default     = true
+}
+
+variable "private_subnets" {
+  description = "Create Public subnets for VPC"
+  default     = null
+}
+
+variable "tags" {
+  description = "User-provided tags for the resources"
+  type        = map(string)
+  default     = {}
+}

--- a/recipes/upstream/aws/k3s/README.md
+++ b/recipes/upstream/aws/k3s/README.md
@@ -62,26 +62,3 @@ See full argument list for each module in use:
   - [Rancher](../../../../modules/rancher)
 
 ### Known Issues
-- Terraform plan shows below warnings which can be ignored:
-
-```bash
-Warning: Value for undeclared variable
-
-The root module does not declare a variable named "ssh_private_key_path" but a value was found in file "terraform.tfvars". If you meant to use this value, add a "variable" block to the configuration.
-
-Invalid attribute in provider configuration
-
-with module.rancher_install.provider["registry.terraform.io/hashicorp/kubernetes"],
-on ../../../../modules/rancher/provider.tf line 7, in provider "kubernetes":
-7: provider "kubernetes" {
-```
-- Terraform apply shows below warnings and errors. Please rerun the terraform apply again and it will be successful[(Issue #22)](#22).
-
-```bash
-Warning: 
-
-Helm release "rancher" was created but has a failed status. Use the `helm` command to investigate the error, correct it, then run Terraform again.
-
-Error: 1 error occurred:
-* Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": failed to call webhook: Post "https://rke2-ingress-nginx-controller-admission.kube-system.svc:443/networking/v1/ingresses?timeout=10s": no endpoints available for service "rke2-ingress-nginx-controller-admission"
-```

--- a/recipes/upstream/aws/k3s/docs.md
+++ b/recipes/upstream/aws/k3s/docs.md
@@ -2,14 +2,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.6.0 |
+| <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
-| <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.6.0 |
+| <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.7.0 |
 
 ## Modules
 
@@ -28,7 +28,7 @@
 |------|------|
 | [local_file.kube_config_yaml](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.kube_config_yaml_backup](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [ssh_resource.retrieve_kubeconfig](https://registry.terraform.io/providers/loafoe/ssh/2.6.0/docs/resources/resource) | resource |
+| [ssh_resource.retrieve_kubeconfig](https://registry.terraform.io/providers/loafoe/ssh/2.7.0/docs/resources/resource) | resource |
 | [local_file.ssh_private_key](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 
 ## Inputs
@@ -41,11 +41,12 @@
 | <a name="input_cert_manager_helm_repository"></a> [cert\_manager\_helm\_repository](#input\_cert\_manager\_helm\_repository) | Helm repository for Cert Manager chart | `string` | `null` | no |
 | <a name="input_cert_manager_helm_repository_password"></a> [cert\_manager\_helm\_repository\_password](#input\_cert\_manager\_helm\_repository\_password) | Private Cert Manager helm repository password | `string` | `null` | no |
 | <a name="input_cert_manager_helm_repository_username"></a> [cert\_manager\_helm\_repository\_username](#input\_cert\_manager\_helm\_repository\_username) | Private Cert Manager helm repository username | `string` | `null` | no |
-| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Should create the security group associated with the instance(s) | `bool` | `null` | no |
+| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Create the security group attached to the instance(s) | `bool` | `true` | no |
 | <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `null` | no |
+| <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Create a VPC | `any` | `null` | no |
 | <a name="input_instance_ami"></a> [instance\_ami](#input\_instance\_ami) | Override the default SLES or Ubuntu AMI | `string` | `null` | no |
 | <a name="input_instance_disk_size"></a> [instance\_disk\_size](#input\_instance\_disk\_size) | Specify root disk size (GB) | `string` | `null` | no |
-| <a name="input_instance_security_group"></a> [instance\_security\_group](#input\_instance\_security\_group) | Provide a pre-existing security group ID | `string` | `null` | no |
+| <a name="input_instance_security_group"></a> [instance\_security\_group](#input\_instance\_security\_group) | Provide a pre-existing security group ID to attach to the instance(s) | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for all EC2 instances | `string` | `null` | no |
 | <a name="input_k3s_channel"></a> [k3s\_channel](#input\_k3s\_channel) | K3s channel to use, the latest patch version for the provided minor version will be used | `string` | `null` | no |
 | <a name="input_k3s_config"></a> [k3s\_config](#input\_k3s\_config) | Additional k3s configuration to add to the config.yaml file | `any` | `null` | no |
@@ -55,6 +56,8 @@
 | <a name="input_kube_config_path"></a> [kube\_config\_path](#input\_kube\_config\_path) | The path to write the kubeconfig for the RKE cluster | `string` | `null` | no |
 | <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Use SLES or Ubuntu images when launching instances (sles or ubuntu) | `string` | `"sles"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `null` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Create Public subnets for VPC | `any` | `null` | no |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | Create Public subnets for VPC | `bool` | `true` | no |
 | <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Password to use when bootstrapping Rancher (min 12 characters) | `string` | `"initial-bootstrap-password"` | no |
 | <a name="input_rancher_helm_repository"></a> [rancher\_helm\_repository](#input\_rancher\_helm\_repository) | Helm repository for Rancher chart | `string` | `null` | no |
 | <a name="input_rancher_helm_repository_password"></a> [rancher\_helm\_repository\_password](#input\_rancher\_helm\_repository\_password) | Private Rancher helm repository password | `string` | `null` | no |
@@ -68,8 +71,9 @@
 | <a name="input_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#input\_ssh\_key\_pair\_name) | Specify the SSH key name to use (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_key_pair_path"></a> [ssh\_key\_pair\_path](#input\_ssh\_key\_pair\_path) | Path to the SSH private key used as the key pair (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username used for SSH with sudo access, must align with the AMI in use | `string` | `null` | no |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `string` | `null` | no |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `any` | `null` | no |
 | <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Version of Ubuntu to use for instances (ex: 22.04) | `string` | `"22.04"` | no |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR for AWS VPC | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_wait"></a> [wait](#input\_wait) | An optional wait before installing the Rancher helm chart | `string` | `"20s"` | no |
 | <a name="input_worker_instance_count"></a> [worker\_instance\_count](#input\_worker\_instance\_count) | Number of worker EC2 instances to create | `number` | `null` | no |
 

--- a/recipes/upstream/aws/k3s/main.tf
+++ b/recipes/upstream/aws/k3s/main.tf
@@ -15,7 +15,7 @@ module "k3s_first" {
 
 module "k3s_first_server" {
   source                  = "../../../../modules/infra/aws/ec2"
-  prefix                  = var.prefix
+  prefix                  = "${var.prefix}-cp"
   instance_count          = 1
   instance_type           = var.instance_type
   instance_disk_size      = var.instance_disk_size
@@ -31,6 +31,10 @@ module "k3s_first_server" {
   aws_region              = var.aws_region
   create_security_group   = var.create_security_group
   instance_security_group = var.instance_security_group
+  create_vpc              = var.create_vpc
+  vpc_cidr                = var.vpc_cidr
+  public_subnets          = var.public_subnets
+  private_subnets         = var.private_subnets
   subnet_id               = var.subnet_id
   user_data               = module.k3s_first.k3s_server_user_data
   aws_access_key          = var.aws_access_key
@@ -48,7 +52,7 @@ module "k3s_additional" {
 
 module "k3s_additional_servers" {
   source                  = "../../../../modules/infra/aws/ec2"
-  prefix                  = var.prefix
+  prefix                  = "${var.prefix}-cp"
   instance_count          = var.server_instance_count - 1
   instance_type           = var.instance_type
   instance_disk_size      = var.instance_disk_size
@@ -65,7 +69,8 @@ module "k3s_additional_servers" {
   aws_region              = var.aws_region
   create_security_group   = false
   instance_security_group = module.k3s_first_server.sg-id
-  subnet_id               = var.subnet_id
+  create_vpc              = false
+  subnet_id               = module.k3s_first_server.public_subnets != null ? module.k3s_first_server.public_subnets : var.subnet_id
   user_data               = module.k3s_additional.k3s_server_user_data
   aws_access_key          = var.aws_access_key
   aws_secret_key          = var.aws_secret_key
@@ -73,7 +78,7 @@ module "k3s_additional_servers" {
 
 module "k3s_workers" {
   source                  = "../../../../modules/infra/aws/ec2"
-  prefix                  = var.prefix
+  prefix                  = "${var.prefix}-wrk"
   instance_count          = var.worker_instance_count
   instance_type           = var.instance_type
   instance_disk_size      = var.instance_disk_size
@@ -89,7 +94,8 @@ module "k3s_workers" {
   aws_region              = var.aws_region
   create_security_group   = false
   instance_security_group = module.k3s_first_server.sg-id
-  subnet_id               = var.subnet_id
+  create_vpc              = false
+  subnet_id               = module.k3s_first_server.public_subnets != null ? module.k3s_first_server.public_subnets : var.subnet_id
   user_data               = module.k3s_additional.k3s_worker_user_data
   aws_access_key          = var.aws_access_key
   aws_secret_key          = var.aws_secret_key

--- a/recipes/upstream/aws/k3s/provider.tf
+++ b/recipes/upstream/aws/k3s/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ssh = {
       source  = "loafoe/ssh"
-      version = "2.6.0"
+      version = "2.7.0"
     }
   }
 }

--- a/recipes/upstream/aws/k3s/terraform.tfvars.example
+++ b/recipes/upstream/aws/k3s/terraform.tfvars.example
@@ -38,6 +38,12 @@ worker_instance_count = 1
 ## -- Use spot instances
 # spot_instances = false
 
+## -- Create a VPC (will use the default VPC instead)
+# create_vpc      = false
+# vpc_cidr        = "10.0.0.0/16"
+# public_subnets  = true
+# private_subnets = false
+
 ### -- Use SLES or Ubuntu images when launching instances (sles or ubuntu)
 # os_type = "sles"
 # sles_version = "15-sp6"

--- a/recipes/upstream/aws/k3s/variables.tf
+++ b/recipes/upstream/aws/k3s/variables.tf
@@ -238,21 +238,40 @@ variable "ubuntu_version" {
 }
 
 variable "subnet_id" {
-  type        = string
+  type        = any
   description = "VPC Subnet ID to create the instance(s) in"
   default     = null
 }
 
 variable "create_security_group" {
   type        = bool
-  description = "Should create the security group associated with the instance(s)"
+  description = "Create the security group attached to the instance(s)"
+  default     = true
+}
+
+variable "instance_security_group" {
+  type        = string
+  description = "Provide a pre-existing security group ID to attach to the instance(s)"
   default     = null
 }
 
-# TODO: Add a check based on above value
-variable "instance_security_group" {
-  type        = string
-  description = "Provide a pre-existing security group ID"
+variable "create_vpc" {
+  description = "Create a VPC"
+  default     = null
+}
+
+variable "vpc_cidr" {
+  description = "CIDR for AWS VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "Create Public subnets for VPC"
+  default     = true
+}
+
+variable "private_subnets" {
+  description = "Create Public subnets for VPC"
   default     = null
 }
 

--- a/recipes/upstream/aws/rke/README.md
+++ b/recipes/upstream/aws/rke/README.md
@@ -75,26 +75,3 @@ See full argument list for each module in use:
   - [Rancher](../../../../modules/rancher)
 
 ### Known Issues
-- Terraform plan shows below warnings which can be ignored:
-
-```bash
-Warning: Value for undeclared variable
-
-The root module does not declare a variable named "ssh_private_key_path" but a value was found in file "terraform.tfvars". If you meant to use this value, add a "variable" block to the configuration.
-
-Invalid attribute in provider configuration
-
-with module.rancher_install.provider["registry.terraform.io/hashicorp/kubernetes"],
-on ../../../../modules/rancher/provider.tf line 7, in provider "kubernetes":
-7: provider "kubernetes" {
-```
-- Terraform apply shows below warnings and errors. Please rerun the terraform apply again and it will be successful [(Issue #22)](#22).
-
-```bash
-Warning: 
-
-Helm release "rancher" was created but has a failed status. Use the `helm` command to investigate the error, correct it, then run Terraform again.
-
-Error: 1 error occurred:
-* Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": failed to call webhook: Post "https://rke2-ingress-nginx-controller-admission.kube-system.svc:443/networking/v1/ingresses?timeout=10s": no endpoints available for service "rke2-ingress-nginx-controller-admission"
-```

--- a/recipes/upstream/aws/rke2/README.md
+++ b/recipes/upstream/aws/rke2/README.md
@@ -61,26 +61,3 @@ See full argument list for each module in use:
   - [Rancher](../../../../modules/rancher)
 
 ### Known Issues
-- Terraform plan shows below warnings which can be ignored:
-
-```bash
-Warning: Value for undeclared variable
-
-The root module does not declare a variable named "ssh_private_key_path" but a value was found in file "terraform.tfvars". If you meant to use this value, add a "variable" block to the configuration.
-
-Invalid attribute in provider configuration
-
-with module.rancher_install.provider["registry.terraform.io/hashicorp/kubernetes"],
-on ../../../../modules/rancher/provider.tf line 7, in provider "kubernetes":
-7: provider "kubernetes" {
-```
-- Terraform apply shows below warnings and errors. Please rerun terraform apply again, and it will be successful[(Issue #22)](#22).
-
-```bash
-Warning: 
-
-Helm release "rancher" was created but has a failed status. Use the `helm` command to investigate the error, correct it, then run Terraform again.
-
-Error: 1 error occurred:
-* Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": failed to call webhook: Post "https://rke2-ingress-nginx-controller-admission.kube-system.svc:443/networking/v1/ingresses?timeout=10s": no endpoints available for service "rke2-ingress-nginx-controller-admission"
-```

--- a/recipes/upstream/aws/rke2/docs.md
+++ b/recipes/upstream/aws/rke2/docs.md
@@ -2,14 +2,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.6.0 |
+| <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
-| <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.6.0 |
+| <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.7.0 |
 
 ## Modules
 
@@ -27,7 +27,7 @@
 |------|------|
 | [local_file.kube_config_yaml](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.kube_config_yaml_backup](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [ssh_resource.retrieve_kubeconfig](https://registry.terraform.io/providers/loafoe/ssh/2.6.0/docs/resources/resource) | resource |
+| [ssh_resource.retrieve_kubeconfig](https://registry.terraform.io/providers/loafoe/ssh/2.7.0/docs/resources/resource) | resource |
 | [local_file.ssh_private_key](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 
 ## Inputs
@@ -40,17 +40,20 @@
 | <a name="input_cert_manager_helm_repository"></a> [cert\_manager\_helm\_repository](#input\_cert\_manager\_helm\_repository) | Helm repository for Cert Manager chart | `string` | `null` | no |
 | <a name="input_cert_manager_helm_repository_password"></a> [cert\_manager\_helm\_repository\_password](#input\_cert\_manager\_helm\_repository\_password) | Private Cert Manager helm repository password | `string` | `null` | no |
 | <a name="input_cert_manager_helm_repository_username"></a> [cert\_manager\_helm\_repository\_username](#input\_cert\_manager\_helm\_repository\_username) | Private Cert Manager helm repository username | `string` | `null` | no |
-| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Should create the security group associated with the instance(s) | `bool` | `null` | no |
+| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Create the security group attached to the instance(s) | `bool` | `true` | no |
 | <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `null` | no |
+| <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Create a VPC | `any` | `null` | no |
 | <a name="input_instance_ami"></a> [instance\_ami](#input\_instance\_ami) | Override the default SLES or Ubuntu AMI | `string` | `null` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of EC2 instances to create | `number` | `null` | no |
 | <a name="input_instance_disk_size"></a> [instance\_disk\_size](#input\_instance\_disk\_size) | Specify root disk size (GB) | `string` | `null` | no |
-| <a name="input_instance_security_group"></a> [instance\_security\_group](#input\_instance\_security\_group) | Provide a pre-existing security group ID | `string` | `null` | no |
+| <a name="input_instance_security_group"></a> [instance\_security\_group](#input\_instance\_security\_group) | Provide a pre-existing security group ID to attach to the instance(s) | `string` | `null` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for all EC2 instances | `string` | `null` | no |
 | <a name="input_kube_config_filename"></a> [kube\_config\_filename](#input\_kube\_config\_filename) | Filename to write the kube config | `string` | `null` | no |
 | <a name="input_kube_config_path"></a> [kube\_config\_path](#input\_kube\_config\_path) | The path to write the kubeconfig for the RKE cluster | `string` | `null` | no |
 | <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Use SLES or Ubuntu images when launching instances (sles or ubuntu) | `string` | `"sles"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `null` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | Create Public subnets for VPC | `any` | `null` | no |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | Create Public subnets for VPC | `bool` | `true` | no |
 | <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Password to use when bootstrapping Rancher (min 12 characters) | `string` | `"initial-bootstrap-password"` | no |
 | <a name="input_rancher_helm_repository"></a> [rancher\_helm\_repository](#input\_rancher\_helm\_repository) | Helm repository for Rancher chart | `string` | `null` | no |
 | <a name="input_rancher_helm_repository_password"></a> [rancher\_helm\_repository\_password](#input\_rancher\_helm\_repository\_password) | Private Rancher helm repository password | `string` | `null` | no |
@@ -66,8 +69,9 @@
 | <a name="input_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#input\_ssh\_key\_pair\_name) | Specify the SSH key name to use (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_key_pair_path"></a> [ssh\_key\_pair\_path](#input\_ssh\_key\_pair\_path) | Path to the SSH private key used as the key pair (that's already present in AWS) | `string` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username used for SSH with sudo access, must align with the AMI in use | `string` | `null` | no |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `string` | `null` | no |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | VPC Subnet ID to create the instance(s) in | `any` | `null` | no |
 | <a name="input_ubuntu_version"></a> [ubuntu\_version](#input\_ubuntu\_version) | Version of Ubuntu to use for instances (ex: 22.04) | `string` | `"22.04"` | no |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR for AWS VPC | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_wait"></a> [wait](#input\_wait) | An optional wait before installing the Rancher helm chart | `string` | `"20s"` | no |
 
 ## Outputs

--- a/recipes/upstream/aws/rke2/main.tf
+++ b/recipes/upstream/aws/rke2/main.tf
@@ -14,7 +14,7 @@ module "rke2_first" {
 
 module "rke2_first_server" {
   source                  = "../../../../modules/infra/aws/ec2"
-  prefix                  = var.prefix
+  prefix                  = "${var.prefix}-cp"
   instance_count          = 1
   instance_type           = var.instance_type
   instance_disk_size      = var.instance_disk_size
@@ -30,6 +30,10 @@ module "rke2_first_server" {
   aws_region              = var.aws_region
   create_security_group   = var.create_security_group
   instance_security_group = var.instance_security_group
+  create_vpc              = var.create_vpc
+  vpc_cidr                = var.vpc_cidr
+  public_subnets          = var.public_subnets
+  private_subnets         = var.private_subnets
   subnet_id               = var.subnet_id
   user_data               = module.rke2_first.rke2_user_data
 }
@@ -44,7 +48,7 @@ module "rke2_additional" {
 
 module "rke2_additional_servers" {
   source                  = "../../../../modules/infra/aws/ec2"
-  prefix                  = var.prefix
+  prefix                  = "${var.prefix}-cp"
   instance_count          = var.instance_count - 1
   instance_type           = var.instance_type
   instance_disk_size      = var.instance_disk_size
@@ -61,7 +65,8 @@ module "rke2_additional_servers" {
   aws_region              = var.aws_region
   create_security_group   = false
   instance_security_group = module.rke2_first_server.sg-id
-  subnet_id               = var.subnet_id
+  create_vpc              = false
+  subnet_id               = module.rke2_first_server.public_subnets != null ? module.rke2_first_server.public_subnets : var.subnet_id
   user_data               = module.rke2_additional.rke2_user_data
   aws_access_key          = var.aws_access_key
   aws_secret_key          = var.aws_secret_key

--- a/recipes/upstream/aws/rke2/provider.tf
+++ b/recipes/upstream/aws/rke2/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ssh = {
       source  = "loafoe/ssh"
-      version = "2.6.0"
+      version = "2.7.0"
     }
   }
 }

--- a/recipes/upstream/aws/rke2/terraform.tfvars.example
+++ b/recipes/upstream/aws/rke2/terraform.tfvars.example
@@ -36,6 +36,12 @@ instance_count = 1
 ## -- Use spot instances
 # spot_instances = false
 
+## -- Create a VPC (will use the default VPC instead)
+# create_vpc      = false
+# vpc_cidr        = "10.0.0.0/16"
+# public_subnets  = true
+# private_subnets = false
+
 ### -- Use SLES or Ubuntu images when launching instances (sles or ubuntu)
 # os_type = "sles"
 # sles_version = "15-sp6"

--- a/recipes/upstream/aws/rke2/variables.tf
+++ b/recipes/upstream/aws/rke2/variables.tf
@@ -226,21 +226,40 @@ variable "ubuntu_version" {
 }
 
 variable "subnet_id" {
-  type        = string
+  type        = any
   description = "VPC Subnet ID to create the instance(s) in"
   default     = null
 }
 
 variable "create_security_group" {
   type        = bool
-  description = "Should create the security group associated with the instance(s)"
+  description = "Create the security group attached to the instance(s)"
+  default     = true
+}
+
+variable "instance_security_group" {
+  type        = string
+  description = "Provide a pre-existing security group ID to attach to the instance(s)"
   default     = null
 }
 
-# TODO: Add a check based on above value
-variable "instance_security_group" {
-  type        = string
-  description = "Provide a pre-existing security group ID"
+variable "create_vpc" {
+  description = "Create a VPC"
+  default     = null
+}
+
+variable "vpc_cidr" {
+  description = "CIDR for AWS VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "Create Public subnets for VPC"
+  default     = true
+}
+
+variable "private_subnets" {
+  description = "Create Public subnets for VPC"
   default     = null
 }
 


### PR DESCRIPTION
- Add VPC module, leverages the upstream official module
- Update EC2 module to create VPC/subnet resources conditionally
- Update RKE2/k3s recipes to use module

Tested with RKE2/k3s with `create_vpc = true` and `create_vpc = false` which appear to be working as expected

Example:

```terraform
aws_region = "ap-southeast-2" # AU, Sydney

prefix = "d-k3s-test"

rancher_password = "at-least-12-characters"

server_instance_count = 1
worker_instance_count = 2

create_vpc = true
```