### PR TITLE
Adding RKE2 recipe on DigitalOcean Cloud Provider

### DIFF
--- a/modules/infra/digitalocean/data.tf
+++ b/modules/infra/digitalocean/data.tf
@@ -3,5 +3,5 @@ data "digitalocean_image" "ubuntu" {
 }
 
 data "digitalocean_ssh_key" "terraform" {
-  name = var.ssh_key_pair_name != null ? var.ssh_key_pair_name : resource.digitalocean_ssh_key.key_pair[0].name
+  name = var.ssh_key_pair_name != null ? var.ssh_key_pair_name : (var.create_ssh_key_pair == false && var.rke2_installation == true ? "tf-rancher-up-${var.prefix}" : resource.digitalocean_ssh_key.key_pair[0].name)
 }

--- a/modules/infra/digitalocean/docs.md
+++ b/modules/infra/digitalocean/docs.md
@@ -34,6 +34,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_create_firewall"></a> [create\_firewall](#input\_create\_firewall) | Specify if a firewall to access droplets needs to be created for the instances | `bool` | `true` | no |
 | <a name="input_create_https_loadbalancer"></a> [create\_https\_loadbalancer](#input\_create\_https\_loadbalancer) | Specify if a loadbalancer for port 443 needs to be created for the instances | `bool` | `false` | no |
 | <a name="input_create_k8s_api_loadbalancer"></a> [create\_k8s\_api\_loadbalancer](#input\_create\_k8s\_api\_loadbalancer) | Specify if a loadbalancer for port 6443 needs to be created for the instances | `bool` | `false` | no |
 | <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `false` | no |
@@ -41,8 +42,10 @@ No modules.
 | <a name="input_droplet_count"></a> [droplet\_count](#input\_droplet\_count) | Number of droplets to create | `number` | `3` | no |
 | <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header` | `string` | `"ubuntu-24-10-x64"` | no |
 | <a name="input_droplet_size"></a> [droplet\_size](#input\_droplet\_size) | Size used for all droplets | `string` | `"s-2vcpu-4gb"` | no |
+| <a name="input_extra_droplet_id"></a> [extra\_droplet\_id](#input\_extra\_droplet\_id) | Specifies the droplet ID to be selected when firewall creation | `string` | `null` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `"rancher-terraform"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region that droplets will be deployed to | `string` | `"sfo3"` | no |
+| <a name="input_rke2_installation"></a> [rke2\_installation](#input\_rke2\_installation) | Specifies if rke2 module is being deployed | `bool` | `false` | no |
 | <a name="input_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#input\_ssh\_key\_pair\_name) | Specify the SSH key name to use (that's already present in DigitalOcean) | `string` | `null` | no |
 | <a name="input_ssh_key_pair_path"></a> [ssh\_key\_pair\_path](#input\_ssh\_key\_pair\_path) | Path to the SSH private key used as the key pair (that's already present in DigitalOcean) | `string` | `null` | no |
 | <a name="input_ssh_private_key_path"></a> [ssh\_private\_key\_path](#input\_ssh\_private\_key\_path) | Path to write the generated SSH private key | `string` | `null` | no |

--- a/modules/infra/digitalocean/main.tf
+++ b/modules/infra/digitalocean/main.tf
@@ -37,7 +37,7 @@ resource "digitalocean_droplet" "droplet" {
     host        = self.ipv4_address
     user        = "root"
     type        = "ssh"
-    private_key = var.create_ssh_key_pair ? tls_private_key.ssh_private_key[0].private_key_openssh : (var.create_ssh_key_pair == false && var.rke2_installation == true ? file(pathexpand(local.new_key_pair_path)) : file(pathexpand(var.ssh_key_pair_path)))
+    private_key = var.create_ssh_key_pair ? tls_private_key.ssh_private_key[0].private_key_openssh : (var.create_ssh_key_pair == false && var.ssh_key_pair_path == null && var.rke2_installation == true ? file(pathexpand(local.new_key_pair_path)) : file(pathexpand(var.ssh_key_pair_path)))
     timeout     = "2m"
   }
 

--- a/modules/infra/digitalocean/main.tf
+++ b/modules/infra/digitalocean/main.tf
@@ -1,7 +1,7 @@
 # Condition to use an existing keypair if a keypair name and file is also provided
 locals {
   new_key_pair_path = var.ssh_private_key_path != null ? var.ssh_private_key_path : "${path.cwd}/${var.prefix}-ssh_private_key.pem"
-  all_droplet_ids = var.rke2_installation ? concat(digitalocean_droplet.droplet[*].id, var.extra_droplet_id != null ? [var.extra_droplet_id] : []) : digitalocean_droplet.droplet[*].id
+  all_droplet_ids   = var.rke2_installation ? concat(digitalocean_droplet.droplet[*].id, var.extra_droplet_id != null ? [var.extra_droplet_id] : []) : digitalocean_droplet.droplet[*].id
 }
 
 resource "tls_private_key" "ssh_private_key" {
@@ -99,7 +99,7 @@ resource "digitalocean_loadbalancer" "https_loadbalancer" {
 }
 resource "digitalocean_firewall" "k8s_cluster" {
   count = var.create_firewall ? 1 : 0
-  name = "${var.prefix}-allow-nodes"
+  name  = "${var.prefix}-allow-nodes"
 
   droplet_ids = local.all_droplet_ids
 

--- a/modules/infra/digitalocean/main.tf
+++ b/modules/infra/digitalocean/main.tf
@@ -48,6 +48,7 @@ resource "digitalocean_droplet" "droplet" {
       "echo 'Completed cloud-init!'"
     ])
   }
+
   lifecycle {
     create_before_destroy = true
     ignore_changes        = [image]
@@ -58,6 +59,7 @@ resource "digitalocean_loadbalancer" "k8s_api_loadbalancer" {
   count  = var.create_k8s_api_loadbalancer ? 1 : 0
   name   = "${var.prefix}-6443-lb"
   region = var.region
+
   forwarding_rule {
     entry_port     = 443
     entry_protocol = "https"
@@ -67,6 +69,7 @@ resource "digitalocean_loadbalancer" "k8s_api_loadbalancer" {
 
     tls_passthrough = true
   }
+
   healthcheck {
     port     = 6443
     protocol = "tcp"
@@ -80,6 +83,7 @@ resource "digitalocean_loadbalancer" "https_loadbalancer" {
   count  = var.create_https_loadbalancer ? 1 : 0
   name   = "${var.prefix}-443-lb"
   region = var.region
+
   forwarding_rule {
     entry_port     = 443
     entry_protocol = "https"
@@ -89,6 +93,7 @@ resource "digitalocean_loadbalancer" "https_loadbalancer" {
 
     tls_passthrough = true
   }
+
   healthcheck {
     port     = 443
     protocol = "tcp"
@@ -97,6 +102,7 @@ resource "digitalocean_loadbalancer" "https_loadbalancer" {
   droplet_ids = local.all_droplet_ids
   depends_on  = [digitalocean_droplet.droplet]
 }
+
 resource "digitalocean_firewall" "k8s_cluster" {
   count = var.create_firewall ? 1 : 0
   name  = "${var.prefix}-allow-nodes"

--- a/modules/infra/digitalocean/provider.tf
+++ b/modules/infra/digitalocean/provider.tf
@@ -1,3 +1,0 @@
-provider "digitalocean" {
-  token = var.do_token
-}

--- a/modules/infra/digitalocean/variables.tf
+++ b/modules/infra/digitalocean/variables.tf
@@ -24,7 +24,6 @@ variable "droplet_size" {
   description = "Size used for all droplets"
   default     = "s-2vcpu-4gb"
   nullable    = false
-
 }
 
 variable "prefix" {

--- a/recipes/upstream/digitalocean/rke/docs.md
+++ b/recipes/upstream/digitalocean/rke/docs.md
@@ -1,6 +1,9 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | ~> 2.0 |
 
 ## Providers
 
@@ -27,7 +30,7 @@ No resources.
 | <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `false` | no |
 | <a name="input_do_token"></a> [do\_token](#input\_do\_token) | DigitalOcean Authentication Token | `string` | `null` | no |
 | <a name="input_droplet_count"></a> [droplet\_count](#input\_droplet\_count) | Number of droplets to create | `number` | `3` | no |
-| <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header` | `string` | `"ubuntu-24-10-x64"` | no |
+| <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header` | `string` | `"ubuntu-22-04-x64"` | no |
 | <a name="input_droplet_size"></a> [droplet\_size](#input\_droplet\_size) | Size used for all droplets | `string` | `"s-2vcpu-4gb"` | no |
 | <a name="input_kube_config_filename"></a> [kube\_config\_filename](#input\_kube\_config\_filename) | Filename to write the kube config | `string` | `null` | no |
 | <a name="input_kube_config_path"></a> [kube\_config\_path](#input\_kube\_config\_path) | The path to write the kubeconfig for the RKE cluster | `string` | `null` | no |

--- a/recipes/upstream/digitalocean/rke/outputs.tf
+++ b/recipes/upstream/digitalocean/rke/outputs.tf
@@ -32,4 +32,3 @@ output "k8s_api_loadbalancer_ip" {
 output "https_loadbalancer_ip" {
   value = module.upstream-cluster.https_loadbalancer_ip
 }
-

--- a/recipes/upstream/digitalocean/rke/provider.tf
+++ b/recipes/upstream/digitalocean/rke/provider.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+
+  required_version = ">= 0.14"
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}

--- a/recipes/upstream/digitalocean/rke/variables.tf
+++ b/recipes/upstream/digitalocean/rke/variables.tf
@@ -178,6 +178,6 @@ variable "create_https_loadbalancer" {
 variable "droplet_image" {
   type        = string
   description = "Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header"
-  default     = "ubuntu-24-10-x64"
+  default     = "ubuntu-22-04-x64"
   nullable    = false
 }

--- a/recipes/upstream/digitalocean/rke/variables.tf
+++ b/recipes/upstream/digitalocean/rke/variables.tf
@@ -17,7 +17,6 @@ variable "droplet_size" {
   description = "Size used for all droplets"
   default     = "s-2vcpu-4gb"
   nullable    = false
-
 }
 
 variable "prefix" {
@@ -56,6 +55,7 @@ variable "ssh_key_pair_path" {
   description = "Path to the SSH private key used as the key pair (that's already present in DigitalOcean)"
   default     = null
 }
+
 variable "ssh_private_key_path" {
   type        = string
   description = "Path to write the generated SSH private key"

--- a/recipes/upstream/digitalocean/rke2/README.md
+++ b/recipes/upstream/digitalocean/rke2/README.md
@@ -21,7 +21,7 @@ cd recipes/upstream/digitalocean/rke2
     -  `rancher_password` to specify admin password to access rancher.
 - SSH keys are automatically created unless you define variable `create_ssh_key_pair` as `false`.
 - Modify the `ssh_key_pair_name` variable to contain the name of a public ssh key stored in DigitalOcean and the `ssh_key_pair_path` variable to contain the local path to it's private key when `create_ssh_key_pair` is set to `false`.
-- If an HA cluster need to be deployed, change the `instance_count` variable to 3 or more.
+- If an HA cluster need to be deployed, change the `droplet_count` variable to 3 or more.
 - There are more optional variables which can be tweaked under `terraform.tfvars`.
 
 Execute the below commands to start deployment.

--- a/recipes/upstream/digitalocean/rke2/README.md
+++ b/recipes/upstream/digitalocean/rke2/README.md
@@ -17,18 +17,25 @@ cd recipes/upstream/digitalocean/rke2
     -  `region` to suit your region
     -  `prefix` to give the resources an identifiable name (eg, your initials or first name)
     -  `do_token` to specify the token to authenticate on DigitalOcean API.
-- SSH keys will be automatically created if `create_ssh_key_pair` is set to `true` (default).
+    -  `user_tag` To specify the tag associated to the resources on DigitalOcean.
+    -  `rancher_password` to specify admin password to access rancher.
+- SSH keys are automatically created unless you define variable `create_ssh_key_pair` as `false`.
 - Modify the `ssh_key_pair_name` variable to contain the name of a public ssh key stored in DigitalOcean and the `ssh_key_pair_path` variable to contain the local path to it's private key when `create_ssh_key_pair` is set to `false`.
 - If an HA cluster need to be deployed, change the `instance_count` variable to 3 or more.
-- Modify the `user_tag` variable so that it contains your first initial and last name.
 - There are more optional variables which can be tweaked under `terraform.tfvars`.
 
 Execute the below commands to start deployment.
 
+#### Terraform Apply
+
 ```bash
-terraform init
-terraform plan
-terraform apply
+terraform init -upgrade && terraform apply -auto-approve
+```
+
+#### Terraform Destroy
+
+```bash
+terraform destroy -auto-approve
 ```
 
 The login details will be displayed in the screen once the deployment is successful. It will have the details as below.
@@ -38,12 +45,6 @@ rancher_hostname = "https://rancher.<xx.xx.xx.xx>.sslip.io"
 rancher_password = "initial-admin-password"
 ```
 
-- Destroy the resources when cluster is no more needed.
-```bash
-terraform destroy
-```
-
-**IMPORTANT**: Please retire the services which are deployed using these terraform modules within 48 hours. Soon there will be automation to retire the service automatically after 48 hours but till that is in place it will be the users responsibility to not keep it running more than 48 hours.
 
 See full argument list for each module in use:
   - [DigitalOcean](../../../../modules/infra/digitalocean)

--- a/recipes/upstream/digitalocean/rke2/README.md
+++ b/recipes/upstream/digitalocean/rke2/README.md
@@ -1,39 +1,52 @@
-# Upstream | Google Cloud | Compute Engine x RKE2
+# Upstream | DigitalOcean | RKE2
 
-This module is used to establish a Rancher (local) managment cluster using [Google Compute Engine](https://cloud.google.com/compute?hl=en) and [RKE2](https://docs.rke2.io/).
+This module is used to establish a Rancher (local) management cluster using DigitalOcean and RKE2.
+
+Documentation can be found [here](./docs.md).
 
 ## Usage
 
 ```bash
 git clone https://github.com/rancherlabs/tf-rancher-up.git
-cd recipes/upstream/google-cloud/rke2
+cd recipes/upstream/digitalocean/rke2
 ```
 
-- Copy `./terraform.tfvars.exmaple` to `./terraform.tfvars`
-- Edit `./terraform.tfvars`
+- Copy `terraform.tfvars.example` to `terraform.tfvars`
+- Edit `terraform.tfvars`
   - Update the required variables:
-    -  `prefix` to give the resources an identifiable name (eg, your initials or first name)
-    -  `project_id` to specify in which Project the resources will be created
     -  `region` to suit your region
-    -  `instance_count` to specify the number of instances to create
-    -  `os_type` to specify the OS and the SSH user used to create the VMs (default "sles")
-    -  `rancher_hostname` in order to reach the Rancher console via DNS name
-    -  `rancher_password` to configure the initial Admin password (the password must be at least 12 characters)
-- Make sure you are logged into your Google Account from your local Terminal. See the preparatory steps [here](../../../../modules/infra/google-cloud/README.md).
+    -  `prefix` to give the resources an identifiable name (eg, your initials or first name)
+    -  `do_token` to specify the token to authenticate on DigitalOcean API.
+- SSH keys will be automatically created if `create_ssh_key_pair` is set to `true` (default).
+- Modify the `ssh_key_pair_name` variable to contain the name of a public ssh key stored in DigitalOcean and the `ssh_key_pair_path` variable to contain the local path to it's private key when `create_ssh_key_pair` is set to `false`.
+- If an HA cluster need to be deployed, change the `instance_count` variable to 3 or more.
+- Modify the `user_tag` variable so that it contains your first initial and last name.
+- There are more optional variables which can be tweaked under `terraform.tfvars`.
 
-#### Terraform Apply
-
-```bash
-terraform init -upgrade && terraform apply -auto-approve
-```
-
-#### Terraform Destroy
+Execute the below commands to start deployment.
 
 ```bash
-terraform destroy -auto-approve
+terraform init
+terraform plan
+terraform apply
 ```
+
+The login details will be displayed in the screen once the deployment is successful. It will have the details as below.
+
+```bash
+rancher_hostname = "https://rancher.<xx.xx.xx.xx>.sslip.io"
+rancher_password = "initial-admin-password"
+```
+
+- Destroy the resources when cluster is no more needed.
+```bash
+terraform destroy
+```
+
+**IMPORTANT**: Please retire the services which are deployed using these terraform modules within 48 hours. Soon there will be automation to retire the service automatically after 48 hours but till that is in place it will be the users responsibility to not keep it running more than 48 hours.
 
 See full argument list for each module in use:
-  - Google Compute Engine: https://github.com/rancherlabs/tf-rancher-up/tree/main/modules/infra/google-cloud/compute-engine
-  - RKE2: https://github.com/rancherlabs/tf-rancher-up/tree/main/modules/distribution/rke2
-  - Rancher: https://github.com/rancherlabs/tf-rancher-up/tree/main/modules/rancher
+  - [DigitalOcean](../../../../modules/infra/digitalocean)
+  - [RKE2](../../../../modules/distribution/rke2)
+  - [Rancher](../../../../modules/rancher)
+

--- a/recipes/upstream/digitalocean/rke2/README.md
+++ b/recipes/upstream/digitalocean/rke2/README.md
@@ -1,0 +1,39 @@
+# Upstream | Google Cloud | Compute Engine x RKE2
+
+This module is used to establish a Rancher (local) managment cluster using [Google Compute Engine](https://cloud.google.com/compute?hl=en) and [RKE2](https://docs.rke2.io/).
+
+## Usage
+
+```bash
+git clone https://github.com/rancherlabs/tf-rancher-up.git
+cd recipes/upstream/google-cloud/rke2
+```
+
+- Copy `./terraform.tfvars.exmaple` to `./terraform.tfvars`
+- Edit `./terraform.tfvars`
+  - Update the required variables:
+    -  `prefix` to give the resources an identifiable name (eg, your initials or first name)
+    -  `project_id` to specify in which Project the resources will be created
+    -  `region` to suit your region
+    -  `instance_count` to specify the number of instances to create
+    -  `os_type` to specify the OS and the SSH user used to create the VMs (default "sles")
+    -  `rancher_hostname` in order to reach the Rancher console via DNS name
+    -  `rancher_password` to configure the initial Admin password (the password must be at least 12 characters)
+- Make sure you are logged into your Google Account from your local Terminal. See the preparatory steps [here](../../../../modules/infra/google-cloud/README.md).
+
+#### Terraform Apply
+
+```bash
+terraform init -upgrade && terraform apply -auto-approve
+```
+
+#### Terraform Destroy
+
+```bash
+terraform destroy -auto-approve
+```
+
+See full argument list for each module in use:
+  - Google Compute Engine: https://github.com/rancherlabs/tf-rancher-up/tree/main/modules/infra/google-cloud/compute-engine
+  - RKE2: https://github.com/rancherlabs/tf-rancher-up/tree/main/modules/distribution/rke2
+  - Rancher: https://github.com/rancherlabs/tf-rancher-up/tree/main/modules/rancher

--- a/recipes/upstream/digitalocean/rke2/docs.md
+++ b/recipes/upstream/digitalocean/rke2/docs.md
@@ -1,0 +1,81 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 5.32.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.0 |
+| <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.6.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_local"></a> [local](#provider\_local) | n/a |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.6.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_rancher_install"></a> [rancher\_install](#module\_rancher\_install) | ../../../../modules/rancher | n/a |
+| <a name="module_rke2_additional"></a> [rke2\_additional](#module\_rke2\_additional) | ../../../../modules/distribution/rke2 | n/a |
+| <a name="module_rke2_additional_servers"></a> [rke2\_additional\_servers](#module\_rke2\_additional\_servers) | ../../../../modules/infra/google-cloud/compute-engine | n/a |
+| <a name="module_rke2_first"></a> [rke2\_first](#module\_rke2\_first) | ../../../../modules/distribution/rke2 | n/a |
+| <a name="module_rke2_first_server"></a> [rke2\_first\_server](#module\_rke2\_first\_server) | ../../../../modules/infra/google-cloud/compute-engine | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [local_file.kube_config_yaml](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [null_resource.wait_k8s_services_startup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [ssh_resource.retrieve_kubeconfig](https://registry.terraform.io/providers/loafoe/ssh/2.6.0/docs/resources/resource) | resource |
+| [local_file.ssh_private_key](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bootstrap_rancher"></a> [bootstrap\_rancher](#input\_bootstrap\_rancher) | Bootstrap the Rancher installation | `bool` | `true` | no |
+| <a name="input_create_firewall"></a> [create\_firewall](#input\_create\_firewall) | Google Firewall used for all resources | `bool` | `true` | no |
+| <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `true` | no |
+| <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Specify whether VPC / Subnet should be created for the instances | `bool` | `true` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Type of the disk attached to each node (e.g. 'pd-standard', 'pd-ssd' or 'pd-balanced') | `string` | `"pd-balanced"` | no |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | The number of nodes | `number` | `3` | no |
+| <a name="input_instance_disk_size"></a> [instance\_disk\_size](#input\_instance\_disk\_size) | Size of the disk attached to each node, specified in GB | `number` | `50` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The name of a Google Compute Engine machine type | `string` | `"n2-standard-2"` | no |
+| <a name="input_ip_cidr_range"></a> [ip\_cidr\_range](#input\_ip\_cidr\_range) | Range of private IPs available for the Google Subnet | `string` | `"10.10.0.0/24"` | no |
+| <a name="input_kube_config_filename"></a> [kube\_config\_filename](#input\_kube\_config\_filename) | Filename to write the kube config | `string` | `null` | no |
+| <a name="input_kube_config_path"></a> [kube\_config\_path](#input\_kube\_config\_path) | The path to write the kubeconfig for the RKE cluster | `string` | `null` | no |
+| <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Operating system type (sles or ubuntu) | `string` | `"sles"` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix used in front of all Google resources | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the Google Project that will contain all created resources | `string` | n/a | yes |
+| <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Password to use when bootstrapping Rancher (min 12 characters) | `string` | `"initial-bootstrap-password"` | no |
+| <a name="input_rancher_hostname"></a> [rancher\_hostname](#input\_rancher\_hostname) | Hostname to set when installing Rancher | `string` | `"rancher"` | no |
+| <a name="input_rancher_ingress_class_name"></a> [rancher\_ingress\_class\_name](#input\_rancher\_ingress\_class\_name) | Rancher ingressClassName value | `string` | `"nginx"` | no |
+| <a name="input_rancher_password"></a> [rancher\_password](#input\_rancher\_password) | Password for the Rancher admin account (min 12 characters) | `string` | `null` | no |
+| <a name="input_rancher_service_type"></a> [rancher\_service\_type](#input\_rancher\_service\_type) | Rancher serviceType value | `string` | `"ClusterIP"` | no |
+| <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Rancher version to install | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | Google Region to create the resources | `string` | `"us-west2"` | no |
+| <a name="input_rke2_config"></a> [rke2\_config](#input\_rke2\_config) | Additional RKE2 configuration to add to the config.yaml file | `string` | `null` | no |
+| <a name="input_rke2_token"></a> [rke2\_token](#input\_rke2\_token) | Token to use when configuring RKE2 nodes | `string` | `null` | no |
+| <a name="input_rke2_version"></a> [rke2\_version](#input\_rke2\_version) | Kubernetes version to use for the RKE2 cluster | `string` | `null` | no |
+| <a name="input_ssh_private_key_path"></a> [ssh\_private\_key\_path](#input\_ssh\_private\_key\_path) | The full path where is present the pre-generated SSH PRIVATE key (not generated by Terraform) | `string` | `null` | no |
+| <a name="input_ssh_public_key_path"></a> [ssh\_public\_key\_path](#input\_ssh\_public\_key\_path) | The full path where is present the pre-generated SSH PUBLIC key (not generated by Terraform) | `string` | `null` | no |
+| <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Custom startup script | `string` | `null` | no |
+| <a name="input_subnet"></a> [subnet](#input\_subnet) | Google Subnet used for all resources | `string` | `null` | no |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | Google VPC used for all resources | `string` | `null` | no |
+| <a name="input_waiting_time"></a> [waiting\_time](#input\_waiting\_time) | Waiting time (in seconds) | `number` | `120` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instances_private_ip"></a> [instances\_private\_ip](#output\_instances\_private\_ip) | n/a |
+| <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
+| <a name="output_instances_ssh_username"></a> [instances\_ssh\_username](#output\_instances\_ssh\_username) | Username used for SSH login |
+| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
+| <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/digitalocean/rke2/docs.md
+++ b/recipes/upstream/digitalocean/rke2/docs.md
@@ -3,7 +3,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | 5.32.0 |
+| <a name="requirement_digitalocean"></a> [digitalocean](#requirement\_digitalocean) | ~> 2.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.0.0 |
 | <a name="requirement_ssh"></a> [ssh](#requirement\_ssh) | 2.6.0 |
@@ -22,9 +22,9 @@
 |------|--------|---------|
 | <a name="module_rancher_install"></a> [rancher\_install](#module\_rancher\_install) | ../../../../modules/rancher | n/a |
 | <a name="module_rke2_additional"></a> [rke2\_additional](#module\_rke2\_additional) | ../../../../modules/distribution/rke2 | n/a |
-| <a name="module_rke2_additional_servers"></a> [rke2\_additional\_servers](#module\_rke2\_additional\_servers) | ../../../../modules/infra/google-cloud/compute-engine | n/a |
+| <a name="module_rke2_additional_servers"></a> [rke2\_additional\_servers](#module\_rke2\_additional\_servers) | ../../../../modules/infra/digitalocean/ | n/a |
 | <a name="module_rke2_first"></a> [rke2\_first](#module\_rke2\_first) | ../../../../modules/distribution/rke2 | n/a |
-| <a name="module_rke2_first_server"></a> [rke2\_first\_server](#module\_rke2\_first\_server) | ../../../../modules/infra/google-cloud/compute-engine | n/a |
+| <a name="module_rke2_first_server"></a> [rke2\_first\_server](#module\_rke2\_first\_server) | ../../../../modules/infra/digitalocean/ | n/a |
 
 ## Resources
 
@@ -40,35 +40,34 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bootstrap_rancher"></a> [bootstrap\_rancher](#input\_bootstrap\_rancher) | Bootstrap the Rancher installation | `bool` | `true` | no |
-| <a name="input_create_firewall"></a> [create\_firewall](#input\_create\_firewall) | Google Firewall used for all resources | `bool` | `true` | no |
-| <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `true` | no |
-| <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | Specify whether VPC / Subnet should be created for the instances | `bool` | `true` | no |
-| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Type of the disk attached to each node (e.g. 'pd-standard', 'pd-ssd' or 'pd-balanced') | `string` | `"pd-balanced"` | no |
-| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | The number of nodes | `number` | `3` | no |
-| <a name="input_instance_disk_size"></a> [instance\_disk\_size](#input\_instance\_disk\_size) | Size of the disk attached to each node, specified in GB | `number` | `50` | no |
-| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The name of a Google Compute Engine machine type | `string` | `"n2-standard-2"` | no |
-| <a name="input_ip_cidr_range"></a> [ip\_cidr\_range](#input\_ip\_cidr\_range) | Range of private IPs available for the Google Subnet | `string` | `"10.10.0.0/24"` | no |
+| <a name="input_create_firewall"></a> [create\_firewall](#input\_create\_firewall) | Specify if a firewall to access droplets needs to be created for the instances | `bool` | `true` | no |
+| <a name="input_create_https_loadbalancer"></a> [create\_https\_loadbalancer](#input\_create\_https\_loadbalancer) | Specify if a loadbalancer for port 443 needs to be created for the instances | `bool` | `false` | no |
+| <a name="input_create_k8s_api_loadbalancer"></a> [create\_k8s\_api\_loadbalancer](#input\_create\_k8s\_api\_loadbalancer) | Specify if a loadbalancer for port 6443 needs to be created for the instances | `bool` | `false` | no |
+| <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `false` | no |
+| <a name="input_do_token"></a> [do\_token](#input\_do\_token) | DigitalOcean Authentication Token | `string` | `null` | no |
+| <a name="input_droplet_count"></a> [droplet\_count](#input\_droplet\_count) | Number of droplets to create | `number` | `3` | no |
+| <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header` | `string` | `"ubuntu-24-10-x64"` | no |
+| <a name="input_droplet_size"></a> [droplet\_size](#input\_droplet\_size) | Size used for all droplets | `string` | `"s-2vcpu-4gb"` | no |
 | <a name="input_kube_config_filename"></a> [kube\_config\_filename](#input\_kube\_config\_filename) | Filename to write the kube config | `string` | `null` | no |
 | <a name="input_kube_config_path"></a> [kube\_config\_path](#input\_kube\_config\_path) | The path to write the kubeconfig for the RKE cluster | `string` | `null` | no |
-| <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Operating system type (sles or ubuntu) | `string` | `"sles"` | no |
-| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix used in front of all Google resources | `string` | n/a | yes |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the Google Project that will contain all created resources | `string` | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `"rancher-terraform"` | no |
 | <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Password to use when bootstrapping Rancher (min 12 characters) | `string` | `"initial-bootstrap-password"` | no |
 | <a name="input_rancher_hostname"></a> [rancher\_hostname](#input\_rancher\_hostname) | Hostname to set when installing Rancher | `string` | `"rancher"` | no |
 | <a name="input_rancher_ingress_class_name"></a> [rancher\_ingress\_class\_name](#input\_rancher\_ingress\_class\_name) | Rancher ingressClassName value | `string` | `"nginx"` | no |
 | <a name="input_rancher_password"></a> [rancher\_password](#input\_rancher\_password) | Password for the Rancher admin account (min 12 characters) | `string` | `null` | no |
 | <a name="input_rancher_service_type"></a> [rancher\_service\_type](#input\_rancher\_service\_type) | Rancher serviceType value | `string` | `"ClusterIP"` | no |
 | <a name="input_rancher_version"></a> [rancher\_version](#input\_rancher\_version) | Rancher version to install | `string` | `null` | no |
-| <a name="input_region"></a> [region](#input\_region) | Google Region to create the resources | `string` | `"us-west2"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region that droplets will be deployed to | `string` | `"sfo3"` | no |
 | <a name="input_rke2_config"></a> [rke2\_config](#input\_rke2\_config) | Additional RKE2 configuration to add to the config.yaml file | `string` | `null` | no |
 | <a name="input_rke2_token"></a> [rke2\_token](#input\_rke2\_token) | Token to use when configuring RKE2 nodes | `string` | `null` | no |
 | <a name="input_rke2_version"></a> [rke2\_version](#input\_rke2\_version) | Kubernetes version to use for the RKE2 cluster | `string` | `null` | no |
-| <a name="input_ssh_private_key_path"></a> [ssh\_private\_key\_path](#input\_ssh\_private\_key\_path) | The full path where is present the pre-generated SSH PRIVATE key (not generated by Terraform) | `string` | `null` | no |
-| <a name="input_ssh_public_key_path"></a> [ssh\_public\_key\_path](#input\_ssh\_public\_key\_path) | The full path where is present the pre-generated SSH PUBLIC key (not generated by Terraform) | `string` | `null` | no |
-| <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Custom startup script | `string` | `null` | no |
-| <a name="input_subnet"></a> [subnet](#input\_subnet) | Google Subnet used for all resources | `string` | `null` | no |
-| <a name="input_vpc"></a> [vpc](#input\_vpc) | Google VPC used for all resources | `string` | `null` | no |
-| <a name="input_waiting_time"></a> [waiting\_time](#input\_waiting\_time) | Waiting time (in seconds) | `number` | `120` | no |
+| <a name="input_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#input\_ssh\_key\_pair\_name) | Specify the SSH key name to use (that's already present in DigitalOcean) | `string` | `null` | no |
+| <a name="input_ssh_key_pair_path"></a> [ssh\_key\_pair\_path](#input\_ssh\_key\_pair\_path) | Path to the SSH private key used as the key pair (that's already present in DigitalOcean) | `string` | `null` | no |
+| <a name="input_ssh_private_key_path"></a> [ssh\_private\_key\_path](#input\_ssh\_private\_key\_path) | Path to write the generated SSH private key | `string` | `null` | no |
+| <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | The user account used to connect to droplets via ssh | `string` | `"root"` | no |
+| <a name="input_tag_begin"></a> [tag\_begin](#input\_tag\_begin) | tag number added to DigitalOcean droplet | `string` | `2` | no |
+| <a name="input_user_tag"></a> [user\_tag](#input\_user\_tag) | FirstInitialLastname of user | `string` | n/a | yes |
+| <a name="input_waiting_time"></a> [waiting\_time](#input\_waiting\_time) | An optional wait before installing the Rancher helm chart | `string` | `"20s"` | no |
 
 ## Outputs
 
@@ -76,6 +75,5 @@
 |------|-------------|
 | <a name="output_instances_private_ip"></a> [instances\_private\_ip](#output\_instances\_private\_ip) | n/a |
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
-| <a name="output_instances_ssh_username"></a> [instances\_ssh\_username](#output\_instances\_ssh\_username) | Username used for SSH login |
 | <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/digitalocean/rke2/docs.md
+++ b/recipes/upstream/digitalocean/rke2/docs.md
@@ -43,7 +43,7 @@
 | <a name="input_create_firewall"></a> [create\_firewall](#input\_create\_firewall) | Specify if a firewall to access droplets needs to be created for the instances | `bool` | `true` | no |
 | <a name="input_create_https_loadbalancer"></a> [create\_https\_loadbalancer](#input\_create\_https\_loadbalancer) | Specify if a loadbalancer for port 443 needs to be created for the instances | `bool` | `false` | no |
 | <a name="input_create_k8s_api_loadbalancer"></a> [create\_k8s\_api\_loadbalancer](#input\_create\_k8s\_api\_loadbalancer) | Specify if a loadbalancer for port 6443 needs to be created for the instances | `bool` | `false` | no |
-| <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `false` | no |
+| <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `true` | no |
 | <a name="input_do_token"></a> [do\_token](#input\_do\_token) | DigitalOcean Authentication Token | `string` | `null` | no |
 | <a name="input_droplet_count"></a> [droplet\_count](#input\_droplet\_count) | Number of droplets to create | `number` | `3` | no |
 | <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header` | `string` | `"ubuntu-24-10-x64"` | no |

--- a/recipes/upstream/digitalocean/rke2/main.tf
+++ b/recipes/upstream/digitalocean/rke2/main.tf
@@ -1,0 +1,122 @@
+locals {
+  rke2_installation           = true
+  create_ssh_key_pair         = var.create_ssh_key_pair == true ? false : true
+  kc_path                     = var.kube_config_path != null ? var.kube_config_path : path.cwd
+  kc_file                     = var.kube_config_filename != null ? "${local.kc_path}/${var.kube_config_filename}" : "${local.kc_path}/${var.prefix}_kube_config.yml"
+  first_node_droplet_id       = module.rke2_first_server.droplet_ids
+  create_firewall             = var.create_firewall == true ? false : true
+}
+
+module "rke2_first" {
+  source       = "../../../../modules/distribution/rke2"
+  rke2_token   = var.rke2_token
+  rke2_version = var.rke2_version
+  rke2_config  = var.rke2_config
+}
+
+module "rke2_first_server" {
+  source                      = "../../../../modules/infra/digitalocean/"
+  prefix                      = var.prefix
+  do_token                    = var.do_token
+  droplet_count               = 1
+  droplet_size                = var.droplet_size
+  user_tag                    = var.user_tag
+  ssh_key_pair_name           = var.ssh_key_pair_name
+  ssh_key_pair_path           = var.ssh_key_pair_path
+  region                      = var.region
+  create_ssh_key_pair         = var.create_ssh_key_pair
+  ssh_private_key_path        = var.ssh_private_key_path
+  user_data                   = module.rke2_first.rke2_user_data
+  create_firewall             = var.create_firewall
+  droplet_image               = var.droplet_image
+  rke2_installation           = local.rke2_installation
+}
+
+module "rke2_additional" {
+  source          = "../../../../modules/distribution/rke2"
+  rke2_token      = module.rke2_first.rke2_token
+  rke2_version    = var.rke2_version
+  rke2_config     = var.rke2_config
+  first_server_ip = module.rke2_first_server.droplets_public_ip[0]
+}
+
+module "rke2_additional_servers" {
+  source                      = "../../../../modules/infra/digitalocean/"
+  depends_on                  = [module.rke2_first_server]
+  prefix                      = var.prefix
+  do_token                    = var.do_token
+  droplet_count               = var.droplet_count - 1
+  droplet_size                = var.droplet_size
+  user_tag                    = var.user_tag
+  tag_begin                   = var.tag_begin
+  ssh_key_pair_name           = var.ssh_key_pair_name
+  ssh_key_pair_path           = var.ssh_key_pair_path
+  region                      = var.region
+  create_ssh_key_pair         = local.create_ssh_key_pair
+  ssh_private_key_path        = var.ssh_private_key_path
+  user_data                   = module.rke2_additional.rke2_user_data
+  # create_firewall             = var.create_firewall
+  extra_droplet_id            = local.first_node_droplet_id[0]
+  droplet_image               = var.droplet_image
+  rke2_installation           = local.rke2_installation
+}
+
+data "local_file" "ssh_private_key" {
+  depends_on = [module.rke2_additional_servers]
+  filename = module.rke2_first_server.ssh_key_path
+}
+
+resource "ssh_resource" "retrieve_kubeconfig" {
+  depends_on = [module.rke2_additional_servers]
+
+  host = module.rke2_first_server.droplets_public_ip[0]
+  commands = [
+    "sudo sed 's/127.0.0.1/${module.rke2_first_server.droplets_public_ip[0]}/g' /etc/rancher/rke2/rke2.yaml"
+  ]
+  user        = var.ssh_username
+  private_key = data.local_file.ssh_private_key.content
+}
+
+resource "local_file" "kube_config_yaml" {
+  filename        = pathexpand(local.kc_file)
+  content         = ssh_resource.retrieve_kubeconfig.result
+  file_permission = "0600"
+}
+
+provider "kubernetes" {
+  config_path = local_file.kube_config_yaml.filename
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = local_file.kube_config_yaml.filename
+  }
+}
+
+resource "null_resource" "wait_k8s_services_startup" {
+  depends_on = [local_file.kube_config_yaml]
+
+  provisioner "local-exec" {
+    command = "sleep ${var.waiting_time}"
+  }
+}
+
+locals {
+  rancher_hostname = var.rancher_hostname != null ? join(".", ["${var.rancher_hostname}", module.rke2_first_server.droplets_public_ip[0], "sslip.io"]) : join(".", ["rancher", module.rke2_first_server.droplets_public_ip[0], "sslip.io"])
+}
+
+module "rancher_install" {
+  source                     = "../../../../modules/rancher"
+  dependency                 = [module.rke2_first_server, null_resource.wait_k8s_services_startup]
+  kubeconfig_file            = local_file.kube_config_yaml.filename
+  rancher_hostname           = local.rancher_hostname
+  rancher_bootstrap_password = var.rancher_bootstrap_password
+  rancher_password           = var.rancher_password
+  bootstrap_rancher          = var.bootstrap_rancher
+  rancher_version            = var.rancher_version
+  rancher_additional_helm_values = [
+    "replicas: ${var.droplet_count}",
+    "ingress.ingressClassName: ${var.rancher_ingress_class_name}",
+    "service.type: ${var.rancher_service_type}"
+  ]
+}

--- a/recipes/upstream/digitalocean/rke2/main.tf
+++ b/recipes/upstream/digitalocean/rke2/main.tf
@@ -1,10 +1,8 @@
 locals {
   rke2_installation           = true
-  create_ssh_key_pair         = var.create_ssh_key_pair == true ? false : true
   kc_path                     = var.kube_config_path != null ? var.kube_config_path : path.cwd
   kc_file                     = var.kube_config_filename != null ? "${local.kc_path}/${var.kube_config_filename}" : "${local.kc_path}/${var.prefix}_kube_config.yml"
   first_node_droplet_id       = module.rke2_first_server.droplet_ids
-  create_firewall             = var.create_firewall == true ? false : true
 }
 
 module "rke2_first" {
@@ -27,7 +25,9 @@ module "rke2_first_server" {
   create_ssh_key_pair         = var.create_ssh_key_pair
   ssh_private_key_path        = var.ssh_private_key_path
   user_data                   = module.rke2_first.rke2_user_data
-  create_firewall             = var.create_firewall
+  create_firewall             = false
+  create_https_loadbalancer   = false
+  create_k8s_api_loadbalancer = false
   droplet_image               = var.droplet_image
   rke2_installation           = local.rke2_installation
 }
@@ -52,10 +52,12 @@ module "rke2_additional_servers" {
   ssh_key_pair_name           = var.ssh_key_pair_name
   ssh_key_pair_path           = var.ssh_key_pair_path
   region                      = var.region
-  create_ssh_key_pair         = local.create_ssh_key_pair
+  create_ssh_key_pair         = false
   ssh_private_key_path        = var.ssh_private_key_path
   user_data                   = module.rke2_additional.rke2_user_data
-  # create_firewall             = var.create_firewall
+  create_firewall             = var.create_firewall
+  create_https_loadbalancer   = var.create_https_loadbalancer
+  create_k8s_api_loadbalancer = var.create_k8s_api_loadbalancer
   extra_droplet_id            = local.first_node_droplet_id[0]
   droplet_image               = var.droplet_image
   rke2_installation           = local.rke2_installation

--- a/recipes/upstream/digitalocean/rke2/main.tf
+++ b/recipes/upstream/digitalocean/rke2/main.tf
@@ -1,8 +1,8 @@
 locals {
-  rke2_installation           = true
-  kc_path                     = var.kube_config_path != null ? var.kube_config_path : path.cwd
-  kc_file                     = var.kube_config_filename != null ? "${local.kc_path}/${var.kube_config_filename}" : "${local.kc_path}/${var.prefix}_kube_config.yml"
-  first_node_droplet_id       = module.rke2_first_server.droplet_ids
+  rke2_installation     = true
+  kc_path               = var.kube_config_path != null ? var.kube_config_path : path.cwd
+  kc_file               = var.kube_config_filename != null ? "${local.kc_path}/${var.kube_config_filename}" : "${local.kc_path}/${var.prefix}_kube_config.yml"
+  first_node_droplet_id = module.rke2_first_server.droplet_ids
 }
 
 module "rke2_first" {
@@ -65,7 +65,7 @@ module "rke2_additional_servers" {
 
 data "local_file" "ssh_private_key" {
   depends_on = [module.rke2_additional_servers]
-  filename = module.rke2_first_server.ssh_key_path
+  filename   = module.rke2_first_server.ssh_key_path
 }
 
 resource "ssh_resource" "retrieve_kubeconfig" {

--- a/recipes/upstream/digitalocean/rke2/outputs.tf
+++ b/recipes/upstream/digitalocean/rke2/outputs.tf
@@ -1,0 +1,28 @@
+output "instances_private_ip" {
+  value = concat([module.rke2_first_server.droplets_public_ip], [module.rke2_additional_servers.droplets_public_ip])
+}
+
+output "instances_public_ip" {
+  value = concat([module.rke2_first_server.droplets_public_ip], [module.rke2_additional_servers.droplets_public_ip])
+}
+
+
+# # Uncomment for debugging purposes
+# output "rke2_first_server_config_file" {
+#  value = nonsensitive(module.rke2_first.rke2_user_data)
+# }
+#
+# # Uncomment for debugging purposes
+# output "rke2_additional_servers_config_file" {
+#  value = nonsensitive(module.rke2_additional.rke2_user_data)
+# }
+
+output "rancher_url" {
+  description = "Rancher URL"
+  value       = "https://${module.rancher_install.rancher_hostname}"
+}
+
+output "rancher_password" {
+  description = "Rancher Initial Custom Password"
+  value       = var.rancher_password
+}

--- a/recipes/upstream/digitalocean/rke2/outputs.tf
+++ b/recipes/upstream/digitalocean/rke2/outputs.tf
@@ -6,7 +6,6 @@ output "instances_public_ip" {
   value = concat([module.rke2_first_server.droplets_public_ip], [module.rke2_additional_servers.droplets_public_ip])
 }
 
-
 # # Uncomment for debugging purposes
 # output "rke2_first_server_config_file" {
 #  value = nonsensitive(module.rke2_first.rke2_user_data)

--- a/recipes/upstream/digitalocean/rke2/provider.tf
+++ b/recipes/upstream/digitalocean/rke2/provider.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+
+    ssh = {
+      source  = "loafoe/ssh"
+      version = "2.6.0"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.10.1"
+    }
+  }
+
+  required_version = ">= 0.14"
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}

--- a/recipes/upstream/digitalocean/rke2/terraform.tfvars.example
+++ b/recipes/upstream/digitalocean/rke2/terraform.tfvars.example
@@ -1,5 +1,8 @@
 # Uncomment and change the values below to suit your individual needs
 
+# DigitalOcean authentication token
+# do_token = ""
+
 # Number of droplets to provision
 # droplet_count = 3
 
@@ -12,17 +15,27 @@
 # Tag added to resources to identify your resource in 'FirstInitialLastName' format
 # user_tag = "terraform"
 
+# Tag added to the droplet resource when it is being created.
+# user_tag = "terraform"
+
+# Switch on/off new ssh keypair generation for droplet/node ssh connections
+# Private keyfile will be stored at '${path.cwd}/${var.prefix}-ssh_private_key.pem' if 'ssh_private_key_path' is empty
+# create_ssh_key_pair = "false"
+
+# If 'create_ssh_key_pair' is set to false, give the name of an ssh key on DigitalOcean
+# ssh_key_pair_name = "terraform"
+
+# If 'ssh_key_pair_path' is set to false, give the path where private key associated with the ssh key uploaded to DigitalOcean is stored.
+# ssh_key_pair_path =  "~/.ssh/terraform.pem"
+
+# Optionally, specify the filepath to write the generated SSH private key
+# ssh_private_key_path = "~/.ssh/rancher-tf-up.pem"
+
 # The region that droplets will be deployed to
 # region = "sfo2"
 
-# Desired Kubernetes version
-# kubernetes_version = "v1.24.17-rancher1-1"
-
-# Admin password to set for Rancher
-# rancher_password = "at-least-12-characters"
-
-# Desired Rancher version
-# rancher_version = "2.6.13"
+# ssh username used to access DigitalOcean droplets
+# ssh_username = "root"
 
 # Filepath for where the new cluster's kubeconfig will be stored
 # kube_config_path = "~/.kube/"
@@ -30,25 +43,38 @@
 # Name of the kubeconfig file
 # kube_config_filename = "tf-rancher-up.yaml"
 
-# Switch on/off new ssh keypair generation for droplet/node ssh connections
-# Private keyfile will be stored at '${path.cwd}/${var.prefix}-ssh_private_key.pem' if 'ssh_private_key_path' is empty
-# create_ssh_key_pair = "false"
+## -- RKE2 version
+# rke2_version = "v1.28.3+rke2r2"
 
-# Optionally, specify the filepath to write the generated SSH private key
-# ssh_private_key_path = "~/.ssh/rancher-tf-up.pem"
+## -- RKE2 token, override the programmatically generated token
+# rke2_token = "string here"
 
-# If 'create_ssh_key_pair' is set to false, give the name of an ssh key on DigitalOcean
-# ssh_key_pair_name = "terraform"
+## -- RKE2 custom config file
+# rke2_config = "<RKE2_CONFIG_FILE>"
 
-## -- Override the default (./${prefix}_kube_config.yml) kubeconfig path and filename
-# kube_config_path = "~/.kube"
-# kube_config_filename = "rancher-terraform.yml"
+## -- Bootstrap the Rancher installation
+# bootstrap_rancher = false
 
-# DigitalOcean authentication token
-# do_token = ""
+## -- Hostname to set when installing Rancher
+# rancher_hostname = "rancher"
+
+## -- Admin password to set for Rancher
+# rancher_password = "at-least-12-characters"
+
+## -- Rancher version to use when installing the Rancher helm chart, otherwise use the latest in the stable repository
+# rancher_version = "2.7.3"
+
+## -- Rancher ingressClassName value
+# rancher_ingress_class_name = "nginx"
+
+## -- Rancher serviceType value
+# rancher_service_type = "ClusterIP"
 
 # Create a loadbalancer resource to route https traffic across all droplets
 # create_https_loadbalancer = false
 
 # Create a loadbalancer resource to route kubernetes apiserver traffic across all droplets
 # create_k8s_api_loadbalancer = false
+
+# Create DigitalOcean Firewall associated with droplets
+# create_firewall = true

--- a/recipes/upstream/digitalocean/rke2/terraform.tfvars.example
+++ b/recipes/upstream/digitalocean/rke2/terraform.tfvars.example
@@ -1,0 +1,54 @@
+# Uncomment and change the values below to suit your individual needs
+
+# Number of droplets to provision
+# droplet_count = 3
+
+# Droplet Machine Type/Size
+# droplet_size = "g-4vcpu-16gb"
+
+# A string that will prefix the name of all resources
+# prefix = "terraform-rancher-support"
+
+# Tag added to resources to identify your resource in 'FirstInitialLastName' format
+# user_tag = "terraform"
+
+# The region that droplets will be deployed to
+# region = "sfo2"
+
+# Desired Kubernetes version
+# kubernetes_version = "v1.24.17-rancher1-1"
+
+# Admin password to set for Rancher
+# rancher_password = "at-least-12-characters"
+
+# Desired Rancher version
+# rancher_version = "2.6.13"
+
+# Filepath for where the new cluster's kubeconfig will be stored
+# kube_config_path = "~/.kube/"
+
+# Name of the kubeconfig file
+# kube_config_filename = "tf-rancher-up.yaml"
+
+# Switch on/off new ssh keypair generation for droplet/node ssh connections
+# Private keyfile will be stored at '${path.cwd}/${var.prefix}-ssh_private_key.pem' if 'ssh_private_key_path' is empty
+# create_ssh_key_pair = "false"
+
+# Optionally, specify the filepath to write the generated SSH private key
+# ssh_private_key_path = "~/.ssh/rancher-tf-up.pem"
+
+# If 'create_ssh_key_pair' is set to false, give the name of an ssh key on DigitalOcean
+# ssh_key_pair_name = "terraform"
+
+## -- Override the default (./${prefix}_kube_config.yml) kubeconfig path and filename
+# kube_config_path = "~/.kube"
+# kube_config_filename = "rancher-terraform.yml"
+
+# DigitalOcean authentication token
+# do_token = ""
+
+# Create a loadbalancer resource to route https traffic across all droplets
+# create_https_loadbalancer = false
+
+# Create a loadbalancer resource to route kubernetes apiserver traffic across all droplets
+# create_k8s_api_loadbalancer = false

--- a/recipes/upstream/digitalocean/rke2/variables.tf
+++ b/recipes/upstream/digitalocean/rke2/variables.tf
@@ -175,7 +175,6 @@ variable "rancher_service_type" {
   default     = "ClusterIP"
 }
 
-
 variable "waiting_time" {
   description = "An optional wait before installing the Rancher helm chart"
   default     = "20s"
@@ -184,23 +183,23 @@ variable "waiting_time" {
 variable "create_k8s_api_loadbalancer" {
   type        = bool
   description = "Specify if a loadbalancer for port 6443 needs to be created for the instances"
-  default     = true
+  default     = false
   nullable    = false
 }
 
 variable "create_https_loadbalancer" {
   type        = bool
   description = "Specify if a loadbalancer for port 443 needs to be created for the instances"
-  default     = true
-  nullable    = false
-}
-variable "create_firewall" {
-  type        = bool
-  description = "Specify if a firewall to access droplets needs to be created for the instances"
   default     = false
   nullable    = false
 }
 
+variable "create_firewall" {
+  type        = bool
+  description = "Specify if a firewall to access droplets needs to be created for the instances"
+  default     = true
+  nullable    = false
+}
 
 variable "droplet_image" {
   type        = string

--- a/recipes/upstream/digitalocean/rke2/variables.tf
+++ b/recipes/upstream/digitalocean/rke2/variables.tf
@@ -17,7 +17,6 @@ variable "droplet_size" {
   description = "Size used for all droplets"
   default     = "s-2vcpu-4gb"
   nullable    = false
-
 }
 
 variable "prefix" {
@@ -121,7 +120,6 @@ variable "rke2_config" {
   type        = string
   default     = null
 }
-
 
 variable "bootstrap_rancher" {
   description = "Bootstrap the Rancher installation"

--- a/recipes/upstream/digitalocean/rke2/variables.tf
+++ b/recipes/upstream/digitalocean/rke2/variables.tf
@@ -12,13 +12,6 @@ variable "droplet_count" {
   nullable    = false
 }
 
-variable "extra_droplet_id" {
-  type        = string
-  description = "Specifies the droplet ID to be selected when firewall creation"
-  default     = null
-  nullable    = true
-}
-
 variable "droplet_size" {
   type        = string
   description = "Size used for all droplets"
@@ -31,19 +24,18 @@ variable "prefix" {
   type        = string
   description = "Prefix added to names of all resources"
   default     = "rancher-terraform"
-  nullable    = false
-}
-
-variable "tag_begin" {
-  type        = number
-  description = "Tag from this number when module is called more than once"
-  default     = 1
 }
 
 variable "user_tag" {
   type        = string
   description = "FirstInitialLastname of user"
   nullable    = false
+}
+
+variable "tag_begin" {
+  type        = string
+  description = "tag number added to DigitalOcean droplet"
+  default     = 2
 }
 
 variable "create_ssh_key_pair" {
@@ -64,7 +56,6 @@ variable "ssh_key_pair_path" {
   description = "Path to the SSH private key used as the key pair (that's already present in DigitalOcean)"
   default     = null
 }
-
 variable "ssh_private_key_path" {
   type        = string
   description = "Path to write the generated SSH private key"
@@ -94,41 +85,126 @@ variable "region" {
   }
 }
 
-variable "user_data" {
-  description = "User data content for EC2 instance(s)"
+variable "ssh_username" {
+  description = "The user account used to connect to droplets via ssh"
+  type        = string
+  default     = "root"
+  nullable    = false
+}
+
+variable "kube_config_path" {
+  description = "The path to write the kubeconfig for the RKE cluster"
+  type        = string
   default     = null
+}
+
+variable "kube_config_filename" {
+  description = "Filename to write the kube config"
+  type        = string
+  default     = null
+}
+
+variable "rke2_version" {
+  description = "Kubernetes version to use for the RKE2 cluster"
+  type        = string
+  default     = null
+}
+
+variable "rke2_token" {
+  description = "Token to use when configuring RKE2 nodes"
+  type        = string
+  default     = null
+}
+
+variable "rke2_config" {
+  description = "Additional RKE2 configuration to add to the config.yaml file"
+  type        = string
+  default     = null
+}
+
+
+variable "bootstrap_rancher" {
+  description = "Bootstrap the Rancher installation"
+  type        = bool
+  default     = true
+}
+
+variable "rancher_hostname" {
+  description = "Hostname to set when installing Rancher"
+  type        = string
+  default     = "rancher"
+}
+
+variable "rancher_bootstrap_password" {
+  description = "Password to use when bootstrapping Rancher (min 12 characters)"
+  default     = "initial-bootstrap-password"
+  type        = string
+
+  validation {
+    condition     = length(var.rancher_bootstrap_password) >= 12
+    error_message = "The password provided for Rancher (rancher_bootstrap_password) must be at least 12 characters"
+  }
+}
+
+variable "rancher_password" {
+  description = "Password for the Rancher admin account (min 12 characters)"
+  default     = null
+  type        = string
+
+  validation {
+    condition     = length(var.rancher_password) >= 12
+    error_message = "The password provided for Rancher (rancher_password) must be at least 12 characters"
+  }
+}
+
+variable "rancher_version" {
+  description = "Rancher version to install"
+  default     = null
+  type        = string
+}
+
+variable "rancher_ingress_class_name" {
+  description = "Rancher ingressClassName value"
+  type        = string
+  default     = "nginx"
+}
+
+variable "rancher_service_type" {
+  description = "Rancher serviceType value"
+  type        = string
+  default     = "ClusterIP"
+}
+
+
+variable "waiting_time" {
+  description = "An optional wait before installing the Rancher helm chart"
+  default     = "20s"
 }
 
 variable "create_k8s_api_loadbalancer" {
   type        = bool
   description = "Specify if a loadbalancer for port 6443 needs to be created for the instances"
-  default     = false
+  default     = true
   nullable    = false
 }
 
 variable "create_https_loadbalancer" {
   type        = bool
   description = "Specify if a loadbalancer for port 443 needs to be created for the instances"
+  default     = true
+  nullable    = false
+}
+variable "create_firewall" {
+  type        = bool
+  description = "Specify if a firewall to access droplets needs to be created for the instances"
   default     = false
   nullable    = false
 }
 
-variable "create_firewall" {
-  type        = bool
-  description = "Specify if a firewall to access droplets needs to be created for the instances"
-  default     = true
-  nullable    = false
-}
 
 variable "droplet_image" {
   type        = string
   description = "Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header"
   default     = "ubuntu-24-10-x64"
   nullable    = false
-}
-
-variable "rke2_installation" {
-  type        = bool
-  description = "Specifies if rke2 module is being deployed"
-  default     = false
 }

--- a/recipes/upstream/digitalocean/rke2/variables.tf
+++ b/recipes/upstream/digitalocean/rke2/variables.tf
@@ -41,7 +41,7 @@ variable "tag_begin" {
 variable "create_ssh_key_pair" {
   type        = bool
   description = "Specify if a new SSH key pair needs to be created for the instances"
-  default     = false
+  default     = true
   nullable    = false
 }
 


### PR DESCRIPTION
Hello team, 

I have been working on the issue https://github.com/rancher/tf-rancher-up/issues/183 and I'm creating this PullRequest because I just finished the creation of the RKE2 recipe on the digitalOcean Cloud provider.

I have had to modify the DigitalOcean Infra module that was previously created to be able to use it with the RKE2 recipe. I tried to make as less changes as possible in the old infra module but most of them were 100% required to make it work.

As I could have affected RKE module with my changes on the infra code I have included RKE in the tests I have been doing until now. So far all the clusters that I deployed using both recipes have been successfully created without errors.

I have tested the following variables on both recipes:

RKE2 - letting TF create the SSH keys

```bash
do_token = "XXX"
prefix = "jlagos-rke2"
region = "fra1"
create_ssh_key_pair = true
user_tag = "jlagos"
rancher_password = "myrancherpassword123*"
```


RKE2 - with my own ssh keys.

```bash
do_token = "XXX"
prefix = "jlagos-rke2"
region = "fra1"
create_ssh_key_pair = false
ssh_key_pair_name = "jlagos-key"
ssh_key_pair_path = "/Users/javierlagos/.ssh/do-ssh.pem"
user_tag = "jlagos"
rancher_password = "myrancherpassword123*"
```

RKE - letting TF create the SSH keys

```bash
do_token = "XXX"
prefix = "jlagos-rke"
region = "fra1"
create_ssh_key_pair = true
kube_config_path = "/Users/javierlagos/PycharmProjects/tf-rancher-up/recipes/upstream/digitalocean/rke"
user_tag = "jlagos"
rancher_password = "myrancherpassword123*"
```


RKE - with my own ssh keys.

```bash
do_token = "XXXX"
prefix = "jlagos-rke"
region = "fra1"
create_ssh_key_pair = false
ssh_key_pair_name = "jlagos-key"
ssh_key_pair_path = "/Users/javierlagos/.ssh/do-ssh.pem"
kube_config_path = "/Users/javierlagos/PycharmProjects/tf-rancher-up/recipes/upstream/digitalocean/rke"
user_tag = "jlagos"
rancher_password = "myrancherpassword123*"
```


FYI - During the testing process before and after my changes I noticed that RKE recipe was not working as expected (You can test it using the code that is on the default main branch to see that RKE installation does not work). After investigating this topic I came to the conclusion that the issue that was blocking the RKE recipe terraform was on the RKE installation part and more specific with the ubuntu image version used by the RKE recipe (Ubuntu 24-10) as the repos on this image does not contain the specific package version required and installed by cloud-init "docker-ce=5:27.2.*" since the oldest available at the droplet with ubuntu 24-10 is docker-ce -> 5.28.* which makes cloud-init startup script to fail.


To fix this issue I have changed the image used from 24-10 to 22-04 and now it works as expected as the package is available so it gets installed correctly.

Please let me know in case something is wrong or that it can be improved! 

Thanks!
