### PR TITLE
Modifying DO recipes to use OpenSUSE image by default

### DIFF
--- a/modules/infra/digitalocean/data.tf
+++ b/modules/infra/digitalocean/data.tf
@@ -1,5 +1,11 @@
 data "digitalocean_image" "ubuntu" {
-  slug = var.droplet_image
+  count = var.os_type == "ubuntu" ? 1 : 0
+  slug  = "ubuntu-22-04-x64"
+}
+
+data "digitalocean_image" "opensuse" {
+  count = var.os_type == "opensuse" ? 1 : 0
+  name  = var.droplet_image
 }
 
 data "digitalocean_ssh_key" "terraform" {

--- a/modules/infra/digitalocean/docs.md
+++ b/modules/infra/digitalocean/docs.md
@@ -27,6 +27,7 @@ No modules.
 | [digitalocean_ssh_key.key_pair](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/ssh_key) | resource |
 | [local_file.private_key_pem](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [tls_private_key.ssh_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [digitalocean_image.opensuse](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/image) | data source |
 | [digitalocean_image.ubuntu](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/image) | data source |
 | [digitalocean_ssh_key.terraform](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/ssh_key) | data source |
 
@@ -43,6 +44,7 @@ No modules.
 | <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header` | `string` | `"ubuntu-24-10-x64"` | no |
 | <a name="input_droplet_size"></a> [droplet\_size](#input\_droplet\_size) | Size used for all droplets | `string` | `"s-2vcpu-4gb"` | no |
 | <a name="input_extra_droplet_id"></a> [extra\_droplet\_id](#input\_extra\_droplet\_id) | Specifies the droplet ID to be selected when firewall creation | `string` | `null` | no |
+| <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Operating system type (opensuse or ubuntu) | `string` | `"opensuse"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `"rancher-terraform"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region that droplets will be deployed to | `string` | `"sfo3"` | no |
 | <a name="input_rke2_installation"></a> [rke2\_installation](#input\_rke2\_installation) | Specifies if rke2 module is being deployed | `bool` | `false` | no |

--- a/modules/infra/digitalocean/main.tf
+++ b/modules/infra/digitalocean/main.tf
@@ -24,7 +24,7 @@ resource "digitalocean_ssh_key" "key_pair" {
 
 resource "digitalocean_droplet" "droplet" {
   count      = var.droplet_count
-  image      = data.digitalocean_image.ubuntu.id
+  image      = var.os_type == "opensuse" ? data.digitalocean_image.opensuse[0].id : data.digitalocean_image.ubuntu[0].id
   size       = var.droplet_size
   name       = "${var.prefix}-${count.index + var.tag_begin}"
   tags       = ["user:${var.user_tag}", "creator:${var.prefix}"]
@@ -45,7 +45,12 @@ resource "digitalocean_droplet" "droplet" {
     inline = flatten([
       "echo 'Waiting for cloud-init to complete...'",
       "cloud-init status --wait > /dev/null",
-      "echo 'Completed cloud-init!'"
+      "echo 'Completed cloud-init!'",
+      var.os_type == "opensuse" ? [
+        "echo 'installing iptables package (openSUSE)'",
+        "zypper --non-interactive refresh > /dev/null 2>&1",
+        "zypper --non-interactive install iptables > /dev/null 2>&1"
+      ] : []
     ])
   }
 

--- a/modules/infra/digitalocean/variables.tf
+++ b/modules/infra/digitalocean/variables.tf
@@ -131,3 +131,14 @@ variable "rke2_installation" {
   description = "Specifies if rke2 module is being deployed"
   default     = false
 }
+
+variable "os_type" {
+  description = "Operating system type (opensuse or ubuntu)"
+  type        = string
+  default     = "opensuse"
+
+  validation {
+    condition     = contains(["opensuse", "ubuntu"], var.os_type)
+    error_message = "The operating system type must be 'opensuse' or 'ubuntu'."
+  }
+}

--- a/recipes/upstream/digitalocean/rke/README.md
+++ b/recipes/upstream/digitalocean/rke/README.md
@@ -21,6 +21,8 @@ cd recipes/upstream/digitalocean/rke
 export TF_VAR_do_token=dop_v1_xxxxxxxxx
 ```
 - Alternatively, you can uncomment `do_token` in `terraform.tfvars` and input the required auth token there.
+- Variable `os_type` defines operating system used by DigitalOcean droplets. it is possible to choose between `ubuntu` or `opensuse` but, by default, the variable is defined as `opensuse`
+- Define variable `droplet_image` with the name of the OpenSUSE image uploaded to the DigitalOcean account when `os_type` has been defined as `opensuse`. The validated OpenSUSE image is openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud that can be downloaded [here](https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2). The steps to upload an image to Digitalocean can be found [here](https://docs.digitalocean.com/products/custom-images/how-to/upload/). 
 - SSH keys will be automatically created if `create_ssh_key_pair` is set to `true` (default).
 - Modify the `ssh_key_pair_name` variable to contain the name of a public ssh key stored in DigitalOcean and the `ssh_key_pair_path` variable to contain the local path to it's private key when `create_ssh_key_pair` is set to `false`.
 - If an HA cluster need to be deployed, change the `instance_count` variable to 3 or more.

--- a/recipes/upstream/digitalocean/rke/docs.md
+++ b/recipes/upstream/digitalocean/rke/docs.md
@@ -30,11 +30,12 @@ No resources.
 | <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `false` | no |
 | <a name="input_do_token"></a> [do\_token](#input\_do\_token) | DigitalOcean Authentication Token | `string` | `null` | no |
 | <a name="input_droplet_count"></a> [droplet\_count](#input\_droplet\_count) | Number of droplets to create | `number` | `3` | no |
-| <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header` | `string` | `"ubuntu-22-04-x64"` | no |
+| <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | name of the OpenSUSE custom image uploaded to DigitalOcean account | `string` | `"openSUSE-Leap-15.6"` | no |
 | <a name="input_droplet_size"></a> [droplet\_size](#input\_droplet\_size) | Size used for all droplets | `string` | `"s-2vcpu-4gb"` | no |
 | <a name="input_kube_config_filename"></a> [kube\_config\_filename](#input\_kube\_config\_filename) | Filename to write the kube config | `string` | `null` | no |
 | <a name="input_kube_config_path"></a> [kube\_config\_path](#input\_kube\_config\_path) | The path to write the kubeconfig for the RKE cluster | `string` | `null` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version to use for the RKE cluster | `string` | `null` | no |
+| <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Operating system type (opensuse or ubuntu) | `string` | `"opensuse"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `"rancher-terraform"` | no |
 | <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Password to use when bootstrapping Rancher (min 12 characters) | `string` | `"initial-bootstrap-password"` | no |
 | <a name="input_rancher_helm_repository"></a> [rancher\_helm\_repository](#input\_rancher\_helm\_repository) | Helm repository for Rancher chart | `string` | `null` | no |

--- a/recipes/upstream/digitalocean/rke/main.tf
+++ b/recipes/upstream/digitalocean/rke/main.tf
@@ -1,24 +1,25 @@
 locals {
   rancher_hostname = var.create_https_loadbalancer ? module.upstream-cluster.https_loadbalancer_ip : module.upstream-cluster.droplets_public_ip[0]
+  startup_script   = var.os_type == "ubuntu" ? templatefile("${path.module}/cloud-config.yaml", {}) : "#!/bin/bash\nzypper --non-interactive install docker && sudo systemctl enable --now docker"
 }
 
 module "upstream-cluster" {
-  source               = "../../../../modules/infra/digitalocean"
-  prefix               = var.prefix
-  do_token             = var.do_token
-  droplet_count        = var.droplet_count
-  droplet_size         = var.droplet_size
-  user_tag             = var.user_tag
-  ssh_key_pair_name    = var.ssh_key_pair_name
-  ssh_key_pair_path    = var.ssh_key_pair_path
-  region               = var.region
-  create_ssh_key_pair  = var.create_ssh_key_pair
-  ssh_private_key_path = var.ssh_private_key_path
-  user_data = templatefile("${path.module}/cloud-config.yaml",
-  {})
+  source                      = "../../../../modules/infra/digitalocean"
+  prefix                      = var.prefix
+  do_token                    = var.do_token
+  droplet_count               = var.droplet_count
+  droplet_size                = var.droplet_size
+  user_tag                    = var.user_tag
+  ssh_key_pair_name           = var.ssh_key_pair_name
+  ssh_key_pair_path           = var.ssh_key_pair_path
+  region                      = var.region
+  create_ssh_key_pair         = var.create_ssh_key_pair
+  ssh_private_key_path        = var.ssh_private_key_path
+  user_data                   = local.startup_script
   create_https_loadbalancer   = var.create_https_loadbalancer
   create_k8s_api_loadbalancer = var.create_k8s_api_loadbalancer
   droplet_image               = var.droplet_image
+  os_type                     = var.os_type
 }
 
 module "rke" {

--- a/recipes/upstream/digitalocean/rke/terraform.tfvars.example
+++ b/recipes/upstream/digitalocean/rke/terraform.tfvars.example
@@ -6,6 +6,12 @@
 # Droplet Machine Type/Size
 # droplet_size = "g-4vcpu-16gb"
 
+# Droplet Operating system. By default variable is set opensuse but ubuntu can also be selected.
+# os_type = "opensuse"
+
+# Name of the OpenSUSE leap image uploaded to the DO account.
+# droplet_image = "openSUSE-Leap-15.6"
+
 # A string that will prefix the name of all resources 
 # prefix = "terraform-rancher-support"
 

--- a/recipes/upstream/digitalocean/rke/variables.tf
+++ b/recipes/upstream/digitalocean/rke/variables.tf
@@ -192,4 +192,3 @@ variable "os_type" {
     error_message = "The operating system type must be 'opensuse' or 'ubuntu'."
   }
 }
-

--- a/recipes/upstream/digitalocean/rke/variables.tf
+++ b/recipes/upstream/digitalocean/rke/variables.tf
@@ -177,7 +177,19 @@ variable "create_https_loadbalancer" {
 
 variable "droplet_image" {
   type        = string
-  description = "Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header"
-  default     = "ubuntu-22-04-x64"
+  description = "name of the OpenSUSE custom image uploaded to DigitalOcean account"
+  default     = "openSUSE-Leap-15.6"
   nullable    = false
 }
+
+variable "os_type" {
+  description = "Operating system type (opensuse or ubuntu)"
+  type        = string
+  default     = "opensuse"
+
+  validation {
+    condition     = contains(["opensuse", "ubuntu"], var.os_type)
+    error_message = "The operating system type must be 'opensuse' or 'ubuntu'."
+  }
+}
+

--- a/recipes/upstream/digitalocean/rke2/README.md
+++ b/recipes/upstream/digitalocean/rke2/README.md
@@ -19,6 +19,8 @@ cd recipes/upstream/digitalocean/rke2
     -  `do_token` to specify the token to authenticate on DigitalOcean API.
     -  `user_tag` To specify the tag associated to the resources on DigitalOcean.
     -  `rancher_password` to specify admin password to access rancher.
+- Variable `os_type` defines operating system used by DigitalOcean droplets. it is possible to choose between `ubuntu` or `opensuse` but, by default, the variable is defined as `opensuse`
+- Define variable `droplet_image` with the name of the OpenSUSE image uploaded to the DigitalOcean account when `os_type` has been defined as `opensuse`. The validated OpenSUSE image is openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud that can be downloaded [here](https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2). The steps to upload an image to Digitalocean can be found [here](https://docs.digitalocean.com/products/custom-images/how-to/upload/). 
 - SSH keys are automatically created unless you define variable `create_ssh_key_pair` as `false`.
 - Modify the `ssh_key_pair_name` variable to contain the name of a public ssh key stored in DigitalOcean and the `ssh_key_pair_path` variable to contain the local path to it's private key when `create_ssh_key_pair` is set to `false`.
 - If an HA cluster need to be deployed, change the `droplet_count` variable to 3 or more.

--- a/recipes/upstream/digitalocean/rke2/docs.md
+++ b/recipes/upstream/digitalocean/rke2/docs.md
@@ -12,8 +12,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_local"></a> [local](#provider\_local) | n/a |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.5.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
 | <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.6.0 |
 
 ## Modules
@@ -46,10 +46,11 @@
 | <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `true` | no |
 | <a name="input_do_token"></a> [do\_token](#input\_do\_token) | DigitalOcean Authentication Token | `string` | `null` | no |
 | <a name="input_droplet_count"></a> [droplet\_count](#input\_droplet\_count) | Number of droplets to create | `number` | `3` | no |
-| <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header` | `string` | `"ubuntu-24-10-x64"` | no |
+| <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | name of the OpenSUSE custom image uploaded to DigitalOcean account | `string` | `"openSUSE-Leap-15.6"` | no |
 | <a name="input_droplet_size"></a> [droplet\_size](#input\_droplet\_size) | Size used for all droplets | `string` | `"s-2vcpu-4gb"` | no |
 | <a name="input_kube_config_filename"></a> [kube\_config\_filename](#input\_kube\_config\_filename) | Filename to write the kube config | `string` | `null` | no |
 | <a name="input_kube_config_path"></a> [kube\_config\_path](#input\_kube\_config\_path) | The path to write the kubeconfig for the RKE cluster | `string` | `null` | no |
+| <a name="input_os_type"></a> [os\_type](#input\_os\_type) | Operating system type (opensuse or ubuntu) | `string` | `"opensuse"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix added to names of all resources | `string` | `"rancher-terraform"` | no |
 | <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Password to use when bootstrapping Rancher (min 12 characters) | `string` | `"initial-bootstrap-password"` | no |
 | <a name="input_rancher_hostname"></a> [rancher\_hostname](#input\_rancher\_hostname) | Hostname to set when installing Rancher | `string` | `"rancher"` | no |

--- a/recipes/upstream/digitalocean/rke2/main.tf
+++ b/recipes/upstream/digitalocean/rke2/main.tf
@@ -29,6 +29,7 @@ module "rke2_first_server" {
   create_https_loadbalancer   = false
   create_k8s_api_loadbalancer = false
   droplet_image               = var.droplet_image
+  os_type                     = var.os_type
   rke2_installation           = local.rke2_installation
 }
 
@@ -60,6 +61,7 @@ module "rke2_additional_servers" {
   create_k8s_api_loadbalancer = var.create_k8s_api_loadbalancer
   extra_droplet_id            = local.first_node_droplet_id[0]
   droplet_image               = var.droplet_image
+  os_type                     = var.os_type
   rke2_installation           = local.rke2_installation
 }
 

--- a/recipes/upstream/digitalocean/rke2/terraform.tfvars.example
+++ b/recipes/upstream/digitalocean/rke2/terraform.tfvars.example
@@ -9,6 +9,12 @@
 # Droplet Machine Type/Size
 # droplet_size = "g-4vcpu-16gb"
 
+# Droplet Operating system. By default variable is set opensuse but ubuntu can also be selected.
+# os_type = "opensuse"
+
+# Name of the OpenSUSE leap image uploaded to the DO account.
+# droplet_image = "openSUSE-Leap-15.6"
+
 # A string that will prefix the name of all resources
 # prefix = "terraform-rancher-support"
 

--- a/recipes/upstream/digitalocean/rke2/variables.tf
+++ b/recipes/upstream/digitalocean/rke2/variables.tf
@@ -201,7 +201,18 @@ variable "create_firewall" {
 
 variable "droplet_image" {
   type        = string
-  description = "Droplet OS Image. Run `doctl compute image list-distribution' for standard OS images or `doctl compute image list` for application images and use the value under the `Slug` header"
-  default     = "ubuntu-24-10-x64"
+  description = "name of the OpenSUSE custom image uploaded to DigitalOcean account"
+  default     = "openSUSE-Leap-15.6"
   nullable    = false
+}
+
+variable "os_type" {
+  description = "Operating system type (opensuse or ubuntu)"
+  type        = string
+  default     = "opensuse"
+
+  validation {
+    condition     = contains(["opensuse", "ubuntu"], var.os_type)
+    error_message = "The operating system type must be 'opensuse' or 'ubuntu'."
+  }
 }


### PR DESCRIPTION
Hello team, 

I've been working on the issue https://github.com/rancher/tf-rancher-up/issues/23 by modifying the current DigitalOcean recipes to use OpenSUSE image by default while keeping the possibility to also use Ubuntu and I think that I have been able to make the modifications required.

I just want to let you know that DigitalOcean does not have any SUSE image on their marketplace so we need to upload one manually to the account before executing the terraform. I have decided to use the openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud, on the README file within each DigitalOcean recipe you will find the steps to download the image, upload it to the DO account and define the variable with the name you have configured for the image on the account.

With the current changes we can now select either deploying Ubuntu 22-04 as before or Opensuse while Opensuse will be the default option.

You can try to deploy a RKE2 cluster on DigitalOcean with OpenSUSE droplets by using or modifying the following variables.

```console
do_token = "<token>"
prefix = "<prefix>"
region = "<region>"
create_ssh_key_pair = true
user_tag = "<prefix-tag>"
rancher_password = "<rancher-admin-password>"
droplet_image = "<name-of-the-OpenSUSE-leap-15.6-image-uploaded-to-DO-account>"
```

You can try to deploy a RKE2 cluster on DigitalOcean with Ubuntu droplets by using or modifying the following variables.

```console
do_token = "<token>"
prefix = "<prefix>"
region = "<region>"
create_ssh_key_pair = true
user_tag = "<prefix-tag>"
rancher_password = "<rancher-admin-password>"
os_type = "ubuntu"
```

On the other side, you can do the same on RKE with the following variables:

OpenSUSE droplets

```console
do_token = "<token>"
prefix = "<prefix>"
region = "<region>"
create_ssh_key_pair = true
kube_config_path = "<terraform-rke-script-path>"
user_tag = "<prefix-tag>"
rancher_password = "<rancher-admin-password>"
droplet_image = "<name-of-the-OpenSUSE-leap-15.6-image-uploaded-to-DO-account>"
```

Ubuntu droplets

```console
do_token = "<token>"
prefix = "<prefix>"
region = "<region>"
create_ssh_key_pair = true
kube_config_path = "<terraform-rke-script-path>"
user_tag = "<prefix-tag>"
rancher_password = "<rancher-admin-password>"
os_type = "ubuntu"
```

