### PR TITLE
Applying all changes required on issue 189

### DIFF
--- a/modules/infra/digitalocean/docs.md
+++ b/modules/infra/digitalocean/docs.md
@@ -53,7 +53,6 @@ No modules.
 | <a name="input_ssh_private_key_path"></a> [ssh\_private\_key\_path](#input\_ssh\_private\_key\_path) | Path to write the generated SSH private key | `string` | `null` | no |
 | <a name="input_tag_begin"></a> [tag\_begin](#input\_tag\_begin) | Tag from this number when module is called more than once | `number` | `1` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | User data content for EC2 instance(s) | `any` | `null` | no |
-| <a name="input_user_tag"></a> [user\_tag](#input\_user\_tag) | FirstInitialLastname of user | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/infra/digitalocean/main.tf
+++ b/modules/infra/digitalocean/main.tf
@@ -27,7 +27,7 @@ resource "digitalocean_droplet" "droplet" {
   image      = var.os_type == "opensuse" ? data.digitalocean_image.opensuse[0].id : data.digitalocean_image.ubuntu[0].id
   size       = var.droplet_size
   name       = "${var.prefix}-${count.index + var.tag_begin}"
-  tags       = ["user:${var.user_tag}", "creator:${var.prefix}"]
+  tags       = ["user:${var.prefix}", "creator:${var.prefix}"]
   ssh_keys   = var.create_ssh_key_pair ? [digitalocean_ssh_key.key_pair[0].id] : [data.digitalocean_ssh_key.terraform.id]
   user_data  = var.user_data
   region     = var.region

--- a/modules/infra/digitalocean/variables.tf
+++ b/modules/infra/digitalocean/variables.tf
@@ -39,12 +39,6 @@ variable "tag_begin" {
   default     = 1
 }
 
-variable "user_tag" {
-  type        = string
-  description = "FirstInitialLastname of user"
-  nullable    = false
-}
-
 variable "create_ssh_key_pair" {
   type        = bool
   description = "Specify if a new SSH key pair needs to be created for the instances"

--- a/recipes/upstream/digitalocean/rke/README.md
+++ b/recipes/upstream/digitalocean/rke/README.md
@@ -26,7 +26,6 @@ export TF_VAR_do_token=dop_v1_xxxxxxxxx
 - SSH keys will be automatically created if `create_ssh_key_pair` is set to `true` (default).
 - Modify the `ssh_key_pair_name` variable to contain the name of a public ssh key stored in DigitalOcean and the `ssh_key_pair_path` variable to contain the local path to it's private key when `create_ssh_key_pair` is set to `false`.
 - If an HA cluster need to be deployed, change the `instance_count` variable to 3 or more.
-- Modify the `user_tag` variable so that it contains your first initial and last name.
 - There are more optional variables which can be tweaked under `terraform.tfvars`.
 
 **NOTE** you may need to use ` terraform init -upgrade` to upgrade provider versions

--- a/recipes/upstream/digitalocean/rke/docs.md
+++ b/recipes/upstream/digitalocean/rke/docs.md
@@ -7,7 +7,9 @@
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
 
 ## Modules
 
@@ -19,7 +21,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [null_resource.wait-k8s-services-startup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 
 ## Inputs
 
@@ -27,7 +31,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_create_https_loadbalancer"></a> [create\_https\_loadbalancer](#input\_create\_https\_loadbalancer) | Specify if a loadbalancer for port 443 needs to be created for the instances | `bool` | `false` | no |
 | <a name="input_create_k8s_api_loadbalancer"></a> [create\_k8s\_api\_loadbalancer](#input\_create\_k8s\_api\_loadbalancer) | Specify if a loadbalancer for port 6443 needs to be created for the instances | `bool` | `false` | no |
-| <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `false` | no |
+| <a name="input_create_ssh_key_pair"></a> [create\_ssh\_key\_pair](#input\_create\_ssh\_key\_pair) | Specify if a new SSH key pair needs to be created for the instances | `bool` | `true` | no |
 | <a name="input_do_token"></a> [do\_token](#input\_do\_token) | DigitalOcean Authentication Token | `string` | `null` | no |
 | <a name="input_droplet_count"></a> [droplet\_count](#input\_droplet\_count) | Number of droplets to create | `number` | `3` | no |
 | <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | name of the OpenSUSE custom image uploaded to DigitalOcean account | `string` | `"openSUSE-Leap-15.6"` | no |
@@ -49,19 +53,14 @@ No resources.
 | <a name="input_ssh_private_key_path"></a> [ssh\_private\_key\_path](#input\_ssh\_private\_key\_path) | Path to write the generated SSH private key | `string` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | The user account used to connect to droplets via ssh | `string` | `"root"` | no |
 | <a name="input_tag_begin"></a> [tag\_begin](#input\_tag\_begin) | Tag from this number when module is called more than once | `number` | `1` | no |
-| <a name="input_user_tag"></a> [user\_tag](#input\_user\_tag) | FirstInitialLastname of user | `string` | n/a | yes |
 | <a name="input_wait"></a> [wait](#input\_wait) | An optional wait before installing the Rancher helm chart | `string` | `"20s"` | no |
+| <a name="input_waiting_time"></a> [waiting\_time](#input\_waiting\_time) | Waiting time (in seconds) | `number` | `60` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_droplet_ids"></a> [droplet\_ids](#output\_droplet\_ids) | n/a |
 | <a name="output_droplets_private_ip"></a> [droplets\_private\_ip](#output\_droplets\_private\_ip) | n/a |
 | <a name="output_droplets_public_ip"></a> [droplets\_public\_ip](#output\_droplets\_public\_ip) | n/a |
-| <a name="output_https_loadbalancer_ip"></a> [https\_loadbalancer\_ip](#output\_https\_loadbalancer\_ip) | n/a |
-| <a name="output_k8s_api_loadbalancer_ip"></a> [k8s\_api\_loadbalancer\_ip](#output\_k8s\_api\_loadbalancer\_ip) | n/a |
-| <a name="output_rancher_hostname"></a> [rancher\_hostname](#output\_rancher\_hostname) | n/a |
 | <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | n/a |
-| <a name="output_ssh_key_pair_name"></a> [ssh\_key\_pair\_name](#output\_ssh\_key\_pair\_name) | n/a |
-| <a name="output_ssh_key_path"></a> [ssh\_key\_path](#output\_ssh\_key\_path) | n/a |
+| <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/digitalocean/rke/outputs.tf
+++ b/recipes/upstream/digitalocean/rke/outputs.tf
@@ -6,29 +6,15 @@ output "droplets_private_ip" {
   value = module.upstream-cluster.droplets_private_ip
 }
 
-output "rancher_hostname" {
-  value = module.rancher_install.rancher_hostname
+
+output "rancher_url" {
+  description = "Rancher URL"
+  value       = "https://${module.rancher_install.rancher_hostname}"
 }
 
 output "rancher_password" {
   value = var.rancher_password
 }
 
-output "ssh_key_path" {
-  value = module.upstream-cluster.ssh_key_path
-}
 
-output "ssh_key_pair_name" {
-  value = module.upstream-cluster.ssh_key_pair_name
-}
 
-output "droplet_ids" {
-  value = module.upstream-cluster.droplet_ids
-}
-output "k8s_api_loadbalancer_ip" {
-  value = module.upstream-cluster.k8s_api_loadbalancer_ip
-}
-
-output "https_loadbalancer_ip" {
-  value = module.upstream-cluster.https_loadbalancer_ip
-}

--- a/recipes/upstream/digitalocean/rke/terraform.tfvars.example
+++ b/recipes/upstream/digitalocean/rke/terraform.tfvars.example
@@ -15,9 +15,6 @@
 # A string that will prefix the name of all resources 
 # prefix = "terraform-rancher-support"
 
-# Tag added to resources to identify your resource in 'FirstInitialLastName' format
-# user_tag = "terraform"
-
 # The region that droplets will be deployed to
 # region = "sfo2"
 

--- a/recipes/upstream/digitalocean/rke/variables.tf
+++ b/recipes/upstream/digitalocean/rke/variables.tf
@@ -31,16 +31,10 @@ variable "tag_begin" {
   default     = 1
 }
 
-variable "user_tag" {
-  type        = string
-  description = "FirstInitialLastname of user"
-  nullable    = false
-}
-
 variable "create_ssh_key_pair" {
   type        = bool
   description = "Specify if a new SSH key pair needs to be created for the instances"
-  default     = false
+  default     = true
   nullable    = false
 }
 
@@ -90,6 +84,12 @@ variable "ssh_username" {
   type        = string
   default     = "root"
   nullable    = false
+}
+
+variable "waiting_time" {
+  description = "Waiting time (in seconds)"
+  type        = number
+  default     = 60
 }
 
 variable "kube_config_path" {

--- a/recipes/upstream/digitalocean/rke2/README.md
+++ b/recipes/upstream/digitalocean/rke2/README.md
@@ -17,7 +17,6 @@ cd recipes/upstream/digitalocean/rke2
     -  `region` to suit your region
     -  `prefix` to give the resources an identifiable name (eg, your initials or first name)
     -  `do_token` to specify the token to authenticate on DigitalOcean API.
-    -  `user_tag` To specify the tag associated to the resources on DigitalOcean.
     -  `rancher_password` to specify admin password to access rancher.
 - Variable `os_type` defines operating system used by DigitalOcean droplets. it is possible to choose between `ubuntu` or `opensuse` but, by default, the variable is defined as `opensuse`
 - Define variable `droplet_image` with the name of the OpenSUSE image uploaded to the DigitalOcean account when `os_type` has been defined as `opensuse`. The validated OpenSUSE image is openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud that can be downloaded [here](https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2). The steps to upload an image to Digitalocean can be found [here](https://docs.digitalocean.com/products/custom-images/how-to/upload/). 

--- a/recipes/upstream/digitalocean/rke2/docs.md
+++ b/recipes/upstream/digitalocean/rke2/docs.md
@@ -67,7 +67,6 @@
 | <a name="input_ssh_private_key_path"></a> [ssh\_private\_key\_path](#input\_ssh\_private\_key\_path) | Path to write the generated SSH private key | `string` | `null` | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | The user account used to connect to droplets via ssh | `string` | `"root"` | no |
 | <a name="input_tag_begin"></a> [tag\_begin](#input\_tag\_begin) | tag number added to DigitalOcean droplet | `string` | `2` | no |
-| <a name="input_user_tag"></a> [user\_tag](#input\_user\_tag) | FirstInitialLastname of user | `string` | n/a | yes |
 | <a name="input_waiting_time"></a> [waiting\_time](#input\_waiting\_time) | An optional wait before installing the Rancher helm chart | `string` | `"20s"` | no |
 
 ## Outputs

--- a/recipes/upstream/digitalocean/rke2/main.tf
+++ b/recipes/upstream/digitalocean/rke2/main.tf
@@ -18,7 +18,6 @@ module "rke2_first_server" {
   do_token                    = var.do_token
   droplet_count               = 1
   droplet_size                = var.droplet_size
-  user_tag                    = var.user_tag
   ssh_key_pair_name           = var.ssh_key_pair_name
   ssh_key_pair_path           = var.ssh_key_pair_path
   region                      = var.region
@@ -48,7 +47,6 @@ module "rke2_additional_servers" {
   do_token                    = var.do_token
   droplet_count               = var.droplet_count - 1
   droplet_size                = var.droplet_size
-  user_tag                    = var.user_tag
   tag_begin                   = var.tag_begin
   ssh_key_pair_name           = var.ssh_key_pair_name
   ssh_key_pair_path           = var.ssh_key_pair_path

--- a/recipes/upstream/digitalocean/rke2/terraform.tfvars.example
+++ b/recipes/upstream/digitalocean/rke2/terraform.tfvars.example
@@ -18,12 +18,6 @@
 # A string that will prefix the name of all resources
 # prefix = "terraform-rancher-support"
 
-# Tag added to resources to identify your resource in 'FirstInitialLastName' format
-# user_tag = "terraform"
-
-# Tag added to the droplet resource when it is being created.
-# user_tag = "terraform"
-
 # Switch on/off new ssh keypair generation for droplet/node ssh connections
 # Private keyfile will be stored at '${path.cwd}/${var.prefix}-ssh_private_key.pem' if 'ssh_private_key_path' is empty
 # create_ssh_key_pair = "false"

--- a/recipes/upstream/digitalocean/rke2/variables.tf
+++ b/recipes/upstream/digitalocean/rke2/variables.tf
@@ -25,12 +25,6 @@ variable "prefix" {
   default     = "rancher-terraform"
 }
 
-variable "user_tag" {
-  type        = string
-  description = "FirstInitialLastname of user"
-  nullable    = false
-}
-
 variable "tag_begin" {
   type        = string
   description = "tag number added to DigitalOcean droplet"


### PR DESCRIPTION
The following PullRequest has been created dude to the issue number 189 which is asking for solving the following points:

1. the user_tag variable is mandatory. Is there a functional reason? If not, I would link the value of the default prefix variable (RKE and RKE2) -> user_tag variable deleted. The objects now are using the content that will be created based on the prefix defined as variable.
2. the create_ssh_key_pair variable is false by default. To align with other projects, I would make it true by default (RKE and RKE2) -> Done. It is no longer required to defined create_ssh_key_pair variable as true as it is already true by default.
3. only for RKE, you need to specify the kube_config_path variable. Use the logic of the other projects; if not specified, local pwd -> Done by following same logic as on other projects.
4. modify the output values, making them in the same format as the AWS/GCP recipes. -> The current output is the same as it is on AWS or GCP.

You can test to deploy RKE2 and RKE modules by using the following variables:


RKE.

```console
do_token = "XXX"
prefix = "prefix"
region = "region"
rancher_password = "XXX"
```
RKE by specifying a different KubeConfig location and by selecting SSH key already uploaded to digitalOcean Account:

```console
do_token = "XXX"
prefix = "prefix"
region = "region"
rancher_password = "XXX"
create_ssh_key_pair = false
ssh_key_pair_name = "ssh_key_name_on_DO_account"
ssh_key_pair_path = "ssh_key_path"
kube_config_path = "custom_kubeconfig_location"
kube_config_filename = "custom_kubeconfig_name"
```

RKE2

```console
do_token = "XXX"
prefix = "prefix"
region = "region"
rancher_password = "XXX"
```
RKE2 by specifying a different KubeConfig location and by selecting SSH key already uploaded to digitalOcean Account:

```console
do_token = "XXX"
prefix = "prefix"
region = "region"
rancher_password = "XXX"
create_ssh_key_pair = false
ssh_key_pair_name = "ssh_key_name_on_DO_account"
ssh_key_pair_path = "ssh_key_path"
kube_config_path = "custom_kubeconfig_location"
kube_config_filename = "custom_kubeconfig_name"
```
