### PR TITLE
fix(rancher): 'kubernetes_secret' deprecated

### DIFF
--- a/modules/rancher/docs.md
+++ b/modules/rancher/docs.md
@@ -25,9 +25,9 @@ No modules.
 |------|------|
 | [helm_release.cert_manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.rancher](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_secret.image_pull_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
-| [kubernetes_secret.tls_ca](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
-| [kubernetes_secret.tls_rancher_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret_v1.image_pull_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_secret_v1.tls_ca](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_secret_v1.tls_rancher_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [null_resource.bootstrap_message](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.wait_for_rancher](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [rancher2_bootstrap.admin](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/bootstrap) | resource |

--- a/modules/rancher/main.tf
+++ b/modules/rancher/main.tf
@@ -33,7 +33,7 @@ locals {
   cert_manager_helm_values = distinct(flatten([local.cert_manager_default_helm_values, local.cert_manager_airgap_helm_values]))
 }
 
-resource "kubernetes_secret" "tls_rancher_ingress" {
+resource "kubernetes_secret_v1" "tls_rancher_ingress" {
   depends_on = [var.dependency]
   count      = var.tls_source == "secret" ? 1 : 0
   metadata {
@@ -52,7 +52,7 @@ resource "kubernetes_secret" "tls_rancher_ingress" {
   }
 }
 
-resource "kubernetes_secret" "tls_ca" {
+resource "kubernetes_secret_v1" "tls_ca" {
   depends_on = [var.dependency]
   count      = var.tls_source == "secret" && var.cacerts_path != null ? 1 : 0
   metadata {
@@ -69,7 +69,7 @@ resource "kubernetes_secret" "tls_ca" {
   }
 }
 
-resource "kubernetes_secret" "image_pull_secret" {
+resource "kubernetes_secret_v1" "image_pull_secret" {
   depends_on = [var.dependency]
   count      = var.registry_username != null ? 1 : 0
   metadata {


### PR DESCRIPTION
Use `kubernetes_secret_v1` instead. Based on the documentation a drop in replacement. Both have the same argument reference.

https://registry.terraform.io/providers/hashicorp/kubernetes/2.25.1/docs/resources/secret#argument-reference
https://registry.terraform.io/providers/hashicorp/kubernetes/2.25.1/docs/resources/secret_v1

```
│ Warning: Deprecated Resource
│
│   with module.rancher_install.kubernetes_secret.tls_rancher_ingress,
│   on modules/rancher/main.tf line 36, in resource "kubernetes_secret" "tls_rancher_ingress":
│   36: resource "kubernetes_secret" "tls_rancher_ingress" {
│
│ Deprecated; use kubernetes_secret_v1.
│
│ (and 2 more similar warnings elsewhere)
```