### PR TITLE
feat(rancher): add helm options 'atomic' and 'upgrade_install'

### DIFF
--- a/modules/rancher/docs.md
+++ b/modules/rancher/docs.md
@@ -40,9 +40,11 @@ No modules.
 | <a name="input_bootstrap_rancher"></a> [bootstrap\_rancher](#input\_bootstrap\_rancher) | Bootstrap the Rancher installation | `bool` | `true` | no |
 | <a name="input_cacerts_path"></a> [cacerts\_path](#input\_cacerts\_path) | Private CA certificate to use for Rancher UI/API connectivity | `string` | `null` | no |
 | <a name="input_cert_manager_enable"></a> [cert\_manager\_enable](#input\_cert\_manager\_enable) | Install cert-manager even if not needed for Rancher, useful if migrating to certificates | `string` | `false` | no |
+| <a name="input_cert_manager_helm_atomic"></a> [cert\_manager\_helm\_atomic](#input\_cert\_manager\_helm\_atomic) | Purge cert-manager chart on fail | `bool` | `false` | no |
 | <a name="input_cert_manager_helm_repository"></a> [cert\_manager\_helm\_repository](#input\_cert\_manager\_helm\_repository) | Helm repository for Cert Manager chart | `string` | `null` | no |
 | <a name="input_cert_manager_helm_repository_password"></a> [cert\_manager\_helm\_repository\_password](#input\_cert\_manager\_helm\_repository\_password) | Private Cert Manager helm repository password | `string` | `null` | no |
 | <a name="input_cert_manager_helm_repository_username"></a> [cert\_manager\_helm\_repository\_username](#input\_cert\_manager\_helm\_repository\_username) | Private Cert Manager helm repository username | `string` | `null` | no |
+| <a name="input_cert_manager_helm_upgrade_install"></a> [cert\_manager\_helm\_upgrade\_install](#input\_cert\_manager\_helm\_upgrade\_install) | Install the release even if a release not controlled by the provider is present. Equivalent to running 'helm upgrade --install' | `bool` | `false` | no |
 | <a name="input_cert_manager_namespace"></a> [cert\_manager\_namespace](#input\_cert\_manager\_namespace) | Namespace to install cert-manager | `string` | `"cert-manager"` | no |
 | <a name="input_cert_manager_version"></a> [cert\_manager\_version](#input\_cert\_manager\_version) | Version of cert-manager to install | `string` | `"v1.11.0"` | no |
 | <a name="input_default_registry"></a> [default\_registry](#input\_default\_registry) | Default container image registry to pull images in the format of registry.domain.com:port (systemDefaultRegistry helm value) | `string` | `null` | no |
@@ -52,9 +54,11 @@ No modules.
 | <a name="input_rancher_additional_helm_values"></a> [rancher\_additional\_helm\_values](#input\_rancher\_additional\_helm\_values) | Helm options to provide to the Rancher helm chart | `list(string)` | `[]` | no |
 | <a name="input_rancher_antiaffinity"></a> [rancher\_antiaffinity](#input\_rancher\_antiaffinity) | Value for antiAffinity when installing the Rancher helm chart (required/preferred) | `string` | `"required"` | no |
 | <a name="input_rancher_bootstrap_password"></a> [rancher\_bootstrap\_password](#input\_rancher\_bootstrap\_password) | Password to use when bootstrapping Rancher (min 12 characters) | `string` | `"initial-bootstrap-password"` | no |
+| <a name="input_rancher_helm_atomic"></a> [rancher\_helm\_atomic](#input\_rancher\_helm\_atomic) | Purge cert-manager chart on fail | `bool` | `false` | no |
 | <a name="input_rancher_helm_repository"></a> [rancher\_helm\_repository](#input\_rancher\_helm\_repository) | Helm repository for Rancher chart | `string` | `null` | no |
 | <a name="input_rancher_helm_repository_password"></a> [rancher\_helm\_repository\_password](#input\_rancher\_helm\_repository\_password) | Private Rancher helm repository password | `string` | `null` | no |
 | <a name="input_rancher_helm_repository_username"></a> [rancher\_helm\_repository\_username](#input\_rancher\_helm\_repository\_username) | Private Rancher helm repository username | `string` | `null` | no |
+| <a name="input_rancher_helm_upgrade_install"></a> [rancher\_helm\_upgrade\_install](#input\_rancher\_helm\_upgrade\_install) | Install the release even if a release not controlled by the provider is present. Equivalent to running 'helm upgrade --install' | `bool` | `false` | no |
 | <a name="input_rancher_hostname"></a> [rancher\_hostname](#input\_rancher\_hostname) | Value for hostname when installing the Rancher helm chart | `string` | n/a | yes |
 | <a name="input_rancher_namespace"></a> [rancher\_namespace](#input\_rancher\_namespace) | The Rancher release will be deployed to this namespace | `string` | `"cattle-system"` | no |
 | <a name="input_rancher_password"></a> [rancher\_password](#input\_rancher\_password) | Password for the Rancher admin account (min 12 characters) | `string` | `null` | no |

--- a/modules/rancher/main.tf
+++ b/modules/rancher/main.tf
@@ -100,6 +100,8 @@ resource "helm_release" "cert_manager" {
   repository_password = var.cert_manager_helm_repository_password != null ? var.cert_manager_helm_repository_password : null
   version             = var.cert_manager_version
   wait                = false
+  atomic              = var.cert_manager_helm_atomic
+  upgrade_install     = var.cert_manager_helm_upgrade_install
 
   set = [
     for v in local.cert_manager_helm_values : {
@@ -122,6 +124,8 @@ resource "helm_release" "rancher" {
   version             = var.rancher_version
   timeout             = var.helm_timeout
   wait                = true
+  atomic              = var.rancher_helm_atomic
+  upgrade_install     = var.rancher_helm_upgrade_install
 
   set = [
     for v in local.rancher_helm_values : {

--- a/modules/rancher/variables.tf
+++ b/modules/rancher/variables.tf
@@ -115,6 +115,18 @@ variable "rancher_helm_repository_password" {
   type        = string
 }
 
+variable "rancher_helm_atomic" {
+  description = "Purge cert-manager chart on fail"
+  default     = false
+  type        = bool
+}
+
+variable "rancher_helm_upgrade_install" {
+  description = "Install the release even if a release not controlled by the provider is present. Equivalent to running 'helm upgrade --install'"
+  default     = false
+  type        = bool
+}
+
 variable "cert_manager_helm_repository" {
   description = "Helm repository for Cert Manager chart"
   default     = null
@@ -131,6 +143,18 @@ variable "cert_manager_helm_repository_password" {
   description = "Private Cert Manager helm repository password"
   default     = null
   type        = string
+}
+
+variable "cert_manager_helm_atomic" {
+  description = "Purge cert-manager chart on fail"
+  default     = false
+  type        = bool
+}
+
+variable "cert_manager_helm_upgrade_install" {
+  description = "Install the release even if a release not controlled by the provider is present. Equivalent to running 'helm upgrade --install'"
+  default     = false
+  type        = bool
 }
 
 variable "registry_username" {


### PR DESCRIPTION
Allows users to decide how to handle failed or existing deployments.

You might for example run into:

```
╷
│ Error: Error upgrading chart
│
│   with module.rancher_install.helm_release.rancher,
│   on tf-rancher-up/modules/rancher/main.tf line 113, in resource "helm_release" "rancher":
│  113: resource "helm_release" "rancher" {
│
│ Upgrade failed: "rancher" has no deployed releases
╵
```

or

```
╷
│ Error: installation failed
│
│   with module.rancher_install.helm_release.rancher,
│   on tf-rancher-up/modules/rancher/main.tf line 113, in resource "helm_release" "rancher":
│  113: resource "helm_release" "rancher" {
│
│ cannot re-use a name that is still in use
╵
```

That currently can only resolved by manual cleaning up or importing a resource.
Using [upgrade_install](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#upgrade_install-1) is the equivalent of running `helm upgrade --install ...` and gets you out of such a situation.

Result in my env that previously stuck in one of the above errors after setting `upgrade_install` to `true`:

```
module.rancher_install.helm_release.rancher: Creating...
module.rancher_install.helm_release.rancher: Still creating... [10s elapsed]
module.rancher_install.helm_release.rancher: Still creating... [20s elapsed]
module.rancher_install.helm_release.rancher: Creation complete after 25s [id=rancher]
```

This PR also introduces [atomic](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#atomic-1) as another optional way influencing how helm behaves when something fails.
Both new options are disabled by default for the `rancher` and `cert-manager` chart, means it is backward compatible and the current behavior doesn't change. Someone has to explicit define it in their `.tfvars` to use it.