### PR TITLE
Add ingress controller variable, default as traefik

### DIFF
--- a/modules/distribution/rke/docs.md
+++ b/modules/distribution/rke/docs.md
@@ -29,7 +29,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_hostnames"></a> [additional\_hostnames](#input\_additional\_hostnames) | List of additional hostnames and IPs to include in the api server PKI cert | `list(string)` | `null` | no |
-| <a name="input_bastion_host"></a> [bastion\_host](#input\_bastion\_host) | Bastion host configuration to access the RKE nodes | <pre>object({<br>    address      = string<br>    user         = string<br>    ssh_key      = string<br>    ssh_key_path = string<br>  })</pre> | `null` | no |
+| <a name="input_bastion_host"></a> [bastion\_host](#input\_bastion\_host) | Bastion host configuration to access the RKE nodes | <pre>object({<br/>    address      = string<br/>    user         = string<br/>    ssh_key      = string<br/>    ssh_key_path = string<br/>  })</pre> | `null` | no |
 | <a name="input_cloud_provider"></a> [cloud\_provider](#input\_cloud\_provider) | Specify the cloud provider name | `string` | `null` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name for the RKE cluster | `string` | `null` | no |
 | <a name="input_cluster_yaml"></a> [cluster\_yaml](#input\_cluster\_yaml) | cluster.yaml configuration file to apply to the cluster | `string` | `null` | no |
@@ -49,7 +49,7 @@ No modules.
 | <a name="input_private_registry_password"></a> [private\_registry\_password](#input\_private\_registry\_password) | Specify private registry's password | `string` | `null` | no |
 | <a name="input_private_registry_url"></a> [private\_registry\_url](#input\_private\_registry\_url) | Specify the private registry where kubernetes images are hosted. Ex: artifactory.company.com/docker | `string` | `null` | no |
 | <a name="input_private_registry_username"></a> [private\_registry\_username](#input\_private\_registry\_username) | Specify private registry's username | `string` | `null` | no |
-| <a name="input_rancher_nodes"></a> [rancher\_nodes](#input\_rancher\_nodes) | List of compute nodes for Rancher cluster | <pre>list(object({<br>    hostname_override = string<br>    public_ip         = string<br>    private_ip        = string<br>    roles             = list(string)<br>    ssh_key           = string<br>    ssh_key_path      = string<br>  }))</pre> | `null` | no |
+| <a name="input_rancher_nodes"></a> [rancher\_nodes](#input\_rancher\_nodes) | List of compute nodes for Rancher cluster | <pre>list(object({<br/>    hostname_override = string<br/>    public_ip         = string<br/>    private_ip        = string<br/>    roles             = list(string)<br/>    ssh_key           = string<br/>    ssh_key_path      = string<br/>  }))</pre> | `null` | no |
 | <a name="input_ssh_agent_auth"></a> [ssh\_agent\_auth](#input\_ssh\_agent\_auth) | Enable SSH agent authentication | `bool` | `false` | no |
 | <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | Private key used for SSH access to the Rancher server cluster node(s) | `string` | `null` | no |
 | <a name="input_ssh_private_key_path"></a> [ssh\_private\_key\_path](#input\_ssh\_private\_key\_path) | Path to private key used for SSH access to the Rancher server cluster node(s) | `string` | `null` | no |

--- a/modules/downstream/aws/EKS/docs.md
+++ b/modules/downstream/aws/EKS/docs.md
@@ -32,8 +32,8 @@ No modules.
 | <a name="input_cluster_description"></a> [cluster\_description](#input\_cluster\_description) | EKS cluster description | `string` | `null` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The cluster name | `string` | `null` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version for the EKS cluster | `string` | `null` | no |
-| <a name="input_logging_types"></a> [logging\_types](#input\_logging\_types) | EKS control plane logging types | `list(string)` | <pre>[<br>  "audit",<br>  "api"<br>]</pre> | no |
-| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | Configuration for EKS node groups | <pre>list(object({<br>    name          = string<br>    instance_type = string<br>    desired_size  = number<br>    max_size      = number<br>    min_size      = number<br>  }))</pre> | n/a | yes |
+| <a name="input_logging_types"></a> [logging\_types](#input\_logging\_types) | EKS control plane logging types | `list(string)` | <pre>[<br/>  "audit",<br/>  "api"<br/>]</pre> | no |
+| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | Configuration for EKS node groups | <pre>list(object({<br/>    name          = string<br/>    instance_type = string<br/>    desired_size  = number<br/>    max_size      = number<br/>    min_size      = number<br/>  }))</pre> | n/a | yes |
 | <a name="input_private_access"></a> [private\_access](#input\_private\_access) | Enable private API server endpoint | `bool` | `true` | no |
 | <a name="input_public_access"></a> [public\_access](#input\_public\_access) | Enable public API server endpoint | `bool` | `true` | no |
 | <a name="input_rancher_insecure"></a> [rancher\_insecure](#input\_rancher\_insecure) | Skip TLS verification for Rancher API | `bool` | `true` | no |

--- a/modules/downstream/aws/v2/docs.md
+++ b/modules/downstream/aws/v2/docs.md
@@ -40,11 +40,13 @@ No modules.
 | <a name="input_rancher_insecure"></a> [rancher\_insecure](#input\_rancher\_insecure) | Allow insecure connections to Rancher | `bool` | `true` | no |
 | <a name="input_rancher_token"></a> [rancher\_token](#input\_rancher\_token) | Rancher API token | `string` | `null` | no |
 | <a name="input_rancher_url"></a> [rancher\_url](#input\_rancher\_url) | The Rancher server URL | `string` | `null` | no |
+| <a name="input_rke2_ingress"></a> [rke2\_ingress](#input\_rke2\_ingress) | RKE2 ingress deployed (nginx or traefik) | `string` | `"traefik"` | no |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Security Group name for nodes | `string` | `null` | no |
 | <a name="input_spot_instances"></a> [spot\_instances](#input\_spot\_instances) | Use spot instances | `bool` | `null` | no |
 | <a name="input_ssh_user"></a> [ssh\_user](#input\_ssh\_user) | Username used for SSH with sudo access | `string` | `"ubuntu"` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet ID for all resources | `string` | `null` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | Specify root volume size (GB) | `number` | `20` | no |
+| <a name="input_volume_type"></a> [volume\_type](#input\_volume\_type) | Specify volume type | `string` | `"gp3"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | AWS VPC to use, subnet ID and security group must exist in the VPC | `string` | `null` | no |
 | <a name="input_worker_count"></a> [worker\_count](#input\_worker\_count) | Worker pool node count | `number` | `1` | no |
 | <a name="input_worker_node_pool_name"></a> [worker\_node\_pool\_name](#input\_worker\_node\_pool\_name) | Worker pool name | `string` | `"w"` | no |

--- a/modules/downstream/aws/v2/main.tf
+++ b/modules/downstream/aws/v2/main.tf
@@ -19,6 +19,7 @@ resource "rancher2_machine_config_v2" "machine_config" {
     zone                  = var.zone
     root_size             = var.volume_size
     instance_type         = var.instance_type
+    volume_type           = var.volume_type
     request_spot_instance = var.spot_instances
   }
 }
@@ -31,6 +32,7 @@ resource "rancher2_cluster_v2" "cluster" {
 
     machine_global_config = <<-EOF
       cni: "${var.cni_provider}"
+      ingress-controller: "${var.rke2_ingress}"
     EOF
 
     machine_pools {

--- a/modules/downstream/aws/v2/variables.tf
+++ b/modules/downstream/aws/v2/variables.tf
@@ -102,10 +102,22 @@ variable "volume_size" {
   type        = number
 }
 
+variable "volume_type" {
+  description = "Specify volume type"
+  default     = "gp3"
+  type        = string
+}
+
 variable "cni_provider" {
   type        = string
   description = "CNI provider to use"
   default     = "calico"
+}
+
+variable "rke2_ingress" {
+  type        = string
+  description = "RKE2 ingress deployed (nginx or traefik)"
+  default     = "traefik"
 }
 
 variable "vpc_id" {

--- a/modules/downstream/gcp/GKE/docs.md
+++ b/modules/downstream/gcp/GKE/docs.md
@@ -31,7 +31,7 @@ No modules.
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the Rancher GKE cluster | `string` | `"ranchergke"` | no |
 | <a name="input_gcp_credentials_path"></a> [gcp\_credentials\_path](#input\_gcp\_credentials\_path) | Path to the GCP service account JSON file | `string` | `null` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version for the cluster | `string` | `null` | no |
-| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | List of node pools configuration | <pre>list(object({<br>    name                = string<br>    initial_node_count  = optional(number, 1)<br>    version             = optional(string, null)<br>    max_pods_constraint = optional(number, 110)<br>  }))</pre> | n/a | yes |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | List of node pools configuration | <pre>list(object({<br/>    name                = string<br/>    initial_node_count  = optional(number, 1)<br/>    version             = optional(string, null)<br/>    max_pods_constraint = optional(number, 110)<br/>  }))</pre> | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP Project ID where the cluster will be created | `string` | n/a | yes |
 | <a name="input_rancher_insecure"></a> [rancher\_insecure](#input\_rancher\_insecure) | Skip TLS verification for Rancher API | `bool` | `true` | no |
 | <a name="input_rancher_token"></a> [rancher\_token](#input\_rancher\_token) | Rancher API token | `string` | `null` | no |

--- a/recipes/downstream/aws/EKS/docs.md
+++ b/recipes/downstream/aws/EKS/docs.md
@@ -29,8 +29,8 @@ No resources.
 | <a name="input_cluster_description"></a> [cluster\_description](#input\_cluster\_description) | EKS cluster description | `string` | `"Terraform managed EKS cluster"` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the Rancher EKS cluster | `string` | n/a | yes |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version for the EKS cluster | `string` | `null` | no |
-| <a name="input_logging_types"></a> [logging\_types](#input\_logging\_types) | EKS control plane logging types | `list(string)` | <pre>[<br>  "audit",<br>  "api"<br>]</pre> | no |
-| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | Configuration for EKS node groups | <pre>list(object({<br>    name          = string<br>    instance_type = string<br>    desired_size  = number<br>    max_size      = number<br>    min_size      = number<br>  }))</pre> | n/a | yes |
+| <a name="input_logging_types"></a> [logging\_types](#input\_logging\_types) | EKS control plane logging types | `list(string)` | <pre>[<br/>  "audit",<br/>  "api"<br/>]</pre> | no |
+| <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | Configuration for EKS node groups | <pre>list(object({<br/>    name          = string<br/>    instance_type = string<br/>    desired_size  = number<br/>    max_size      = number<br/>    min_size      = number<br/>  }))</pre> | n/a | yes |
 | <a name="input_private_access"></a> [private\_access](#input\_private\_access) | Enable private API server endpoint | `bool` | `true` | no |
 | <a name="input_public_access"></a> [public\_access](#input\_public\_access) | Enable public API server endpoint | `bool` | `true` | no |
 | <a name="input_rancher_insecure"></a> [rancher\_insecure](#input\_rancher\_insecure) | Allow insecure connections to Rancher | `bool` | `true` | no |

--- a/recipes/downstream/aws/v2/docs.md
+++ b/recipes/downstream/aws/v2/docs.md
@@ -36,6 +36,7 @@ No resources.
 | <a name="input_rancher_insecure"></a> [rancher\_insecure](#input\_rancher\_insecure) | Allow insecure connections to Rancher | `bool` | `true` | no |
 | <a name="input_rancher_token"></a> [rancher\_token](#input\_rancher\_token) | Rancher API token | `string` | `null` | no |
 | <a name="input_rancher_url"></a> [rancher\_url](#input\_rancher\_url) | The Rancher server URL | `string` | `null` | no |
+| <a name="input_rke2_ingress"></a> [rke2\_ingress](#input\_rke2\_ingress) | RKE2 ingress deployed (nginx or traefik) | `string` | `"traefik"` | no |
 | <a name="input_security_group_name"></a> [security\_group\_name](#input\_security\_group\_name) | Security Group name for nodes | `string` | `null` | no |
 | <a name="input_spot_instances"></a> [spot\_instances](#input\_spot\_instances) | Use spot instances | `bool` | `null` | no |
 | <a name="input_ssh_user"></a> [ssh\_user](#input\_ssh\_user) | Username used for SSH with sudo access | `string` | `"ubuntu"` | no |

--- a/recipes/downstream/aws/v2/main.tf
+++ b/recipes/downstream/aws/v2/main.tf
@@ -22,4 +22,5 @@ module "downstream_rke2" {
   cp_count              = var.cp_count
   worker_count          = var.worker_count
   cni_provider          = var.cni_provider
+  rke2_ingress          = var.rke2_ingress
 }

--- a/recipes/downstream/aws/v2/terraform.tfvars.example
+++ b/recipes/downstream/aws/v2/terraform.tfvars.example
@@ -57,4 +57,5 @@ kubernetes_version = "v1.27.12+rke2r1"
 # cp_count = 1
 # worker_count = 1
 # cni_provider = "calico"
+# rke2_ingress = "traefik"
 # spot_instances = false

--- a/recipes/downstream/aws/v2/variables.tf
+++ b/recipes/downstream/aws/v2/variables.tf
@@ -143,6 +143,12 @@ variable "cni_provider" {
   default     = "calico"
 }
 
+variable "rke2_ingress" {
+  type        = string
+  description = "RKE2 ingress deployed (nginx or traefik)"
+  default     = "traefik"
+}
+
 variable "vpc_id" {
   description = "AWS VPC to use, subnet ID and security group must exist in the VPC"
   default     = null

--- a/recipes/downstream/gcp/GKE/docs.md
+++ b/recipes/downstream/gcp/GKE/docs.md
@@ -28,7 +28,7 @@ No resources.
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the Rancher GKE cluster | `string` | `"gke-test"` | no |
 | <a name="input_gcp_credentials_path"></a> [gcp\_credentials\_path](#input\_gcp\_credentials\_path) | Path to the GCP service account JSON file | `string` | `null` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version for the cluster | `string` | `null` | no |
-| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | List of node pools configuration | <pre>list(object({<br>    name                = string<br>    initial_node_count  = optional(number, 1)<br>    version             = optional(string, null)<br>    max_pods_constraint = optional(number, 110)<br>  }))</pre> | n/a | yes |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | List of node pools configuration | <pre>list(object({<br/>    name                = string<br/>    initial_node_count  = optional(number, 1)<br/>    version             = optional(string, null)<br/>    max_pods_constraint = optional(number, 110)<br/>  }))</pre> | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP Project ID where the cluster will be created | `string` | n/a | yes |
 | <a name="input_rancher_insecure"></a> [rancher\_insecure](#input\_rancher\_insecure) | Skip TLS verification for Rancher API | `bool` | `true` | no |
 | <a name="input_rancher_token"></a> [rancher\_token](#input\_rancher\_token) | Rancher API token | `string` | `null` | no |

--- a/recipes/rke/split-roles/aws/docs.md
+++ b/recipes/rke/split-roles/aws/docs.md
@@ -25,7 +25,7 @@ No resources.
 | <a name="input_aws_access_key"></a> [aws\_access\_key](#input\_aws\_access\_key) | Enter your AWS access key | `string` | n/a | yes |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region used for all resources | `string` | n/a | yes |
 | <a name="input_aws_secret_key"></a> [aws\_secret\_key](#input\_aws\_secret\_key) | Enter your AWS secret key | `string` | n/a | yes |
-| <a name="input_bastion_host"></a> [bastion\_host](#input\_bastion\_host) | Bastion host configuration to access the RKE nodes | <pre>object({<br>    address      = string<br>    user         = string<br>    ssh_key_path = string<br>    ssh_key      = string<br>  })</pre> | `null` | no |
+| <a name="input_bastion_host"></a> [bastion\_host](#input\_bastion\_host) | Bastion host configuration to access the RKE nodes | <pre>object({<br/>    address      = string<br/>    user         = string<br/>    ssh_key_path = string<br/>    ssh_key      = string<br/>  })</pre> | `null` | no |
 | <a name="input_cloud_provider"></a> [cloud\_provider](#input\_cloud\_provider) | Specify the cloud provider name | `string` | `null` | no |
 | <a name="input_create_kubeconfig_file"></a> [create\_kubeconfig\_file](#input\_create\_kubeconfig\_file) | Boolean flag to generate a kubeconfig file (mostly used for dev only) | `bool` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Should create the security group associated with the instance(s) | `bool` | `true` | no |


### PR DESCRIPTION
Resolves: https://github.com/rancher/tf-rancher-up/issues/228

- Added traefik as default for downstream AWS/RKE2 recipe (v2)

Being v2 the same `machine_global_config` applies for k3s, however Rancher will ignore the ingress controller configuration for k3s. This appeared to be the most elegant way to add this, as both k3s/rke2 use the same resource

- Added gp3 as the default EBS volume type
