### PR TITLE
Having made the rancher_password variable sensitive, it is no longer possible to expose it via outputs.tf files.

### DIFF
--- a/recipes/upstream/aws/k3s/docs.md
+++ b/recipes/upstream/aws/k3s/docs.md
@@ -87,5 +87,4 @@
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
 | <a name="output_rancher_admin_token"></a> [rancher\_admin\_token](#output\_rancher\_admin\_token) | Rancher API token for the admin user |
 | <a name="output_rancher_hostname"></a> [rancher\_hostname](#output\_rancher\_hostname) | n/a |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | n/a |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | n/a |

--- a/recipes/upstream/aws/k3s/outputs.tf
+++ b/recipes/upstream/aws/k3s/outputs.tf
@@ -14,10 +14,6 @@ output "rancher_url" {
   value = "https://${local.rancher_hostname}"
 }
 
-output "rancher_password" {
-  value = var.rancher_password
-}
-
 output "rancher_admin_token" {
   description = "Rancher API token for the admin user"
   value       = module.rancher_install.rancher_admin_token

--- a/recipes/upstream/aws/rke/docs.md
+++ b/recipes/upstream/aws/rke/docs.md
@@ -72,5 +72,4 @@ No resources.
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
 | <a name="output_rancher_admin_token"></a> [rancher\_admin\_token](#output\_rancher\_admin\_token) | Rancher API token for the admin user |
 | <a name="output_rancher_hostname"></a> [rancher\_hostname](#output\_rancher\_hostname) | n/a |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | n/a |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | n/a |

--- a/recipes/upstream/aws/rke/outputs.tf
+++ b/recipes/upstream/aws/rke/outputs.tf
@@ -14,10 +14,6 @@ output "rancher_url" {
   value = "https://${local.rancher_hostname}"
 }
 
-output "rancher_password" {
-  value = var.rancher_password
-}
-
 output "rancher_admin_token" {
   description = "Rancher API token for the admin user"
   value       = module.rancher_install.rancher_admin_token

--- a/recipes/upstream/aws/rke2/docs.md
+++ b/recipes/upstream/aws/rke2/docs.md
@@ -85,5 +85,4 @@
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
 | <a name="output_rancher_admin_token"></a> [rancher\_admin\_token](#output\_rancher\_admin\_token) | Rancher API token for the admin user |
 | <a name="output_rancher_hostname"></a> [rancher\_hostname](#output\_rancher\_hostname) | n/a |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | n/a |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | n/a |

--- a/recipes/upstream/aws/rke2/outputs.tf
+++ b/recipes/upstream/aws/rke2/outputs.tf
@@ -14,10 +14,6 @@ output "rancher_url" {
   value = "https://${local.rancher_hostname}"
 }
 
-output "rancher_password" {
-  value = var.rancher_password
-}
-
 output "rancher_admin_token" {
   description = "Rancher API token for the admin user"
   value       = module.rancher_install.rancher_admin_token

--- a/recipes/upstream/azure/aks/docs.md
+++ b/recipes/upstream/azure/aks/docs.md
@@ -56,5 +56,4 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_rancher_hostname"></a> [rancher\_hostname](#output\_rancher\_hostname) | n/a |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | n/a |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | n/a |

--- a/recipes/upstream/azure/aks/outputs.tf
+++ b/recipes/upstream/azure/aks/outputs.tf
@@ -5,7 +5,3 @@ output "rancher_hostname" {
 output "rancher_url" {
   value = "https://${local.rancher_hostname}"
 }
-
-output "rancher_password" {
-  value = var.rancher_password
-}

--- a/recipes/upstream/azure/k3s/docs.md
+++ b/recipes/upstream/azure/k3s/docs.md
@@ -85,5 +85,4 @@
 | <a name="output_instances_private_ip"></a> [instances\_private\_ip](#output\_instances\_private\_ip) | n/a |
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
 | <a name="output_instances_ssh_username"></a> [instances\_ssh\_username](#output\_instances\_ssh\_username) | Username used for SSH login |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/azure/k3s/outputs.tf
+++ b/recipes/upstream/azure/k3s/outputs.tf
@@ -15,8 +15,3 @@ output "rancher_url" {
   description = "Rancher URL"
   value       = "https://${module.rancher_install.rancher_hostname}"
 }
-
-output "rancher_password" {
-  description = "Rancher Initial Custom Password"
-  value       = var.rancher_password
-}

--- a/recipes/upstream/azure/rke/docs.md
+++ b/recipes/upstream/azure/rke/docs.md
@@ -63,5 +63,4 @@ No resources.
 | <a name="output_instances_private_ip"></a> [instances\_private\_ip](#output\_instances\_private\_ip) | n/a |
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
 | <a name="output_instances_ssh_username"></a> [instances\_ssh\_username](#output\_instances\_ssh\_username) | Username used for SSH login |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/azure/rke/outputs.tf
+++ b/recipes/upstream/azure/rke/outputs.tf
@@ -16,11 +16,6 @@ output "rancher_url" {
   value       = "https://${module.rancher_install.rancher_hostname}"
 }
 
-output "rancher_password" {
-  description = "Rancher Initial Custom Password"
-  value       = var.rancher_password
-}
-
 #output "ingress_nginx_stats" {
 #  value = data.kubernetes_service.ingress-nginx-controller-svc.spec.0.port.1.node_port
 #}

--- a/recipes/upstream/azure/rke2/docs.md
+++ b/recipes/upstream/azure/rke2/docs.md
@@ -83,5 +83,4 @@
 | <a name="output_instances_private_ip"></a> [instances\_private\_ip](#output\_instances\_private\_ip) | n/a |
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
 | <a name="output_instances_ssh_username"></a> [instances\_ssh\_username](#output\_instances\_ssh\_username) | Username used for SSH login |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/azure/rke2/outputs.tf
+++ b/recipes/upstream/azure/rke2/outputs.tf
@@ -25,8 +25,3 @@ output "rancher_url" {
   description = "Rancher URL"
   value       = "https://${module.rancher_install.rancher_hostname}"
 }
-
-output "rancher_password" {
-  description = "Rancher Initial Custom Password"
-  value       = var.rancher_password
-}

--- a/recipes/upstream/digitalocean/k3s/docs.md
+++ b/recipes/upstream/digitalocean/k3s/docs.md
@@ -83,5 +83,4 @@
 | <a name="output_droplets_private_ip"></a> [droplets\_private\_ip](#output\_droplets\_private\_ip) | n/a |
 | <a name="output_droplets_public_ip"></a> [droplets\_public\_ip](#output\_droplets\_public\_ip) | n/a |
 | <a name="output_instances_ssh_username"></a> [instances\_ssh\_username](#output\_instances\_ssh\_username) | Username used for SSH login |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/digitalocean/k3s/outputs.tf
+++ b/recipes/upstream/digitalocean/k3s/outputs.tf
@@ -15,8 +15,3 @@ output "rancher_url" {
   description = "Rancher URL"
   value       = "https://${module.rancher_install.rancher_hostname}"
 }
-
-output "rancher_password" {
-  description = "Rancher Initial Custom Password"
-  value       = var.rancher_password
-}

--- a/recipes/upstream/digitalocean/rke/docs.md
+++ b/recipes/upstream/digitalocean/rke/docs.md
@@ -62,5 +62,4 @@
 |------|-------------|
 | <a name="output_droplets_private_ip"></a> [droplets\_private\_ip](#output\_droplets\_private\_ip) | n/a |
 | <a name="output_droplets_public_ip"></a> [droplets\_public\_ip](#output\_droplets\_public\_ip) | n/a |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | n/a |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/digitalocean/rke/outputs.tf
+++ b/recipes/upstream/digitalocean/rke/outputs.tf
@@ -6,15 +6,7 @@ output "droplets_private_ip" {
   value = module.upstream-cluster.droplets_private_ip
 }
 
-
 output "rancher_url" {
   description = "Rancher URL"
   value       = "https://${module.rancher_install.rancher_hostname}"
 }
-
-output "rancher_password" {
-  value = var.rancher_password
-}
-
-
-

--- a/recipes/upstream/digitalocean/rke2/docs.md
+++ b/recipes/upstream/digitalocean/rke2/docs.md
@@ -81,5 +81,4 @@
 |------|-------------|
 | <a name="output_instances_private_ip"></a> [instances\_private\_ip](#output\_instances\_private\_ip) | n/a |
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/digitalocean/rke2/outputs.tf
+++ b/recipes/upstream/digitalocean/rke2/outputs.tf
@@ -20,8 +20,3 @@ output "rancher_url" {
   description = "Rancher URL"
   value       = "https://${module.rancher_install.rancher_hostname}"
 }
-
-output "rancher_password" {
-  description = "Rancher Initial Custom Password"
-  value       = var.rancher_password
-}

--- a/recipes/upstream/google-cloud/gke/docs.md
+++ b/recipes/upstream/google-cloud/gke/docs.md
@@ -59,5 +59,4 @@
 
 | Name | Description |
 |------|-------------|
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/google-cloud/gke/outputs.tf
+++ b/recipes/upstream/google-cloud/gke/outputs.tf
@@ -2,8 +2,3 @@ output "rancher_url" {
   description = "Rancher URL"
   value       = "https://${module.rancher_install.rancher_hostname}"
 }
-
-output "rancher_password" {
-  description = "Rancher Initial Custom Password"
-  value       = var.rancher_password
-}

--- a/recipes/upstream/google-cloud/k3s/docs.md
+++ b/recipes/upstream/google-cloud/k3s/docs.md
@@ -88,5 +88,4 @@
 | <a name="output_instances_private_ip"></a> [instances\_private\_ip](#output\_instances\_private\_ip) | n/a |
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
 | <a name="output_instances_ssh_username"></a> [instances\_ssh\_username](#output\_instances\_ssh\_username) | Username used for SSH login |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/google-cloud/k3s/outputs.tf
+++ b/recipes/upstream/google-cloud/k3s/outputs.tf
@@ -15,8 +15,3 @@ output "rancher_url" {
   description = "Rancher URL"
   value       = "https://${module.rancher_install.rancher_hostname}"
 }
-
-output "rancher_password" {
-  description = "Rancher Initial Custom Password"
-  value       = var.rancher_password
-}

--- a/recipes/upstream/google-cloud/rke/docs.md
+++ b/recipes/upstream/google-cloud/rke/docs.md
@@ -75,5 +75,4 @@
 | <a name="output_instances_private_ip"></a> [instances\_private\_ip](#output\_instances\_private\_ip) | n/a |
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
 | <a name="output_instances_ssh_username"></a> [instances\_ssh\_username](#output\_instances\_ssh\_username) | Username used for SSH login |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/google-cloud/rke/outputs.tf
+++ b/recipes/upstream/google-cloud/rke/outputs.tf
@@ -16,11 +16,6 @@ output "rancher_url" {
   value       = "https://${module.rancher_install.rancher_hostname}"
 }
 
-output "rancher_password" {
-  description = "Rancher Initial Custom Password"
-  value       = var.rancher_password
-}
-
 #output "ingress_nginx_stats" {
 #  value = data.kubernetes_service.ingress-nginx-controller-svc.spec.0.port.1.node_port
 #}

--- a/recipes/upstream/google-cloud/rke2/docs.md
+++ b/recipes/upstream/google-cloud/rke2/docs.md
@@ -86,5 +86,4 @@
 | <a name="output_instances_private_ip"></a> [instances\_private\_ip](#output\_instances\_private\_ip) | n/a |
 | <a name="output_instances_public_ip"></a> [instances\_public\_ip](#output\_instances\_public\_ip) | n/a |
 | <a name="output_instances_ssh_username"></a> [instances\_ssh\_username](#output\_instances\_ssh\_username) | Username used for SSH login |
-| <a name="output_rancher_password"></a> [rancher\_password](#output\_rancher\_password) | Rancher Initial Custom Password |
 | <a name="output_rancher_url"></a> [rancher\_url](#output\_rancher\_url) | Rancher URL |

--- a/recipes/upstream/google-cloud/rke2/outputs.tf
+++ b/recipes/upstream/google-cloud/rke2/outputs.tf
@@ -25,8 +25,3 @@ output "rancher_url" {
   description = "Rancher URL"
   value       = "https://${module.rancher_install.rancher_hostname}"
 }
-
-output "rancher_password" {
-  description = "Rancher Initial Custom Password"
-  value       = var.rancher_password
-}


### PR DESCRIPTION
Having made the rancher_password variable sensitive, it is no longer possible to expose it via outputs.tf files.

Example:
```
╷
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 29:
│   29: output "rancher_password" ***
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```