### PR TITLE
Improve subnet logic

### DIFF
--- a/modules/infra/aws/ec2/main.tf
+++ b/modules/infra/aws/ec2/main.tf
@@ -1,6 +1,5 @@
 locals {
   new_key_pair_path = var.ssh_private_key_path != null ? var.ssh_private_key_path : "${path.cwd}/${var.prefix}-ssh_private_key.pem"
-  existing_subnet   = var.create_vpc != true && var.subnet_id != null ? var.subnet_id : data.aws_subnets.default_subnets[0].ids
 }
 
 resource "tls_private_key" "ssh_private_key" {
@@ -32,7 +31,7 @@ module "aws_vpc" {
 }
 
 resource "random_shuffle" "subnet" {
-  input        = var.create_vpc == true ? module.aws_vpc[0].public_subnets : tolist(local.existing_subnet)
+  input        = var.create_vpc == true ? module.aws_vpc[0].public_subnets : tolist(var.subnet_id != null ? var.subnet_id : data.aws_subnets.default_subnets[0].ids)
   result_count = var.instance_count
 }
 

--- a/modules/infra/aws/ec2/outputs.tf
+++ b/modules/infra/aws/ec2/outputs.tf
@@ -34,7 +34,7 @@ output "ssh_key_pair_name" {
 }
 
 output "public_subnets" {
-  value = var.create_vpc == true ? module.aws_vpc[0].public_subnets : tolist(local.existing_subnet)
+  value = var.create_vpc == true ? module.aws_vpc[0].public_subnets : tolist(var.subnet_id != null ? var.subnet_id : data.aws_subnets.default_subnets[0].ids)
 }
 
 output "private_subnets" {


### PR DESCRIPTION
Improve logic to avoid referencing the data source when creating a VPC
```
create_vpc      = true
```

```
│ Error: Invalid index
│
│   on ../../../../modules/infra/aws/ec2/main.tf line 3, in locals:
│    3:   existing_subnet   = var.create_vpc != true && var.subnet_id != null ? var.subnet_id : data.aws_subnets.default_subnets[0].ids
│     ├────────────────
│     │ data.aws_subnets.default_subnets is empty tuple
│
│ The given key does not identify an element in this collection value: the collection has no elements.
```