### PR TITLE
Add datasource for EKS as default fallback

### DIFF
--- a/modules/downstream/aws/EKS/main.tf
+++ b/modules/downstream/aws/EKS/main.tf
@@ -1,3 +1,24 @@
+data "aws_eks_cluster_versions" "default" {
+  count        = var.kubernetes_version == null ? 1 : 0
+  default_only = true
+}
+
+resource "null_resource" "kubernetes_version" {
+  count = var.kubernetes_version == null ? 1 : 0
+
+  triggers = {
+    version = data.aws_eks_cluster_versions.default[0].cluster_versions[0].cluster_version
+  }
+
+  lifecycle {
+    ignore_changes = [triggers["version"]]
+  }
+}
+
+locals {
+  kubernetes_version = var.kubernetes_version != null ? var.kubernetes_version : null_resource.kubernetes_version[0].triggers["version"]
+}
+
 resource "rancher2_cloud_credential" "aws_credential" {
   count       = var.cloud_credential_id != null ? 0 : 1
   name        = var.cluster_name
@@ -15,7 +36,7 @@ resource "rancher2_cluster" "ranchereks" {
   eks_config_v2 {
     cloud_credential_id = var.cloud_credential_id != null ? var.cloud_credential_id : rancher2_cloud_credential.aws_credential[0].id
     region              = var.aws_region
-    kubernetes_version  = var.kubernetes_version
+    kubernetes_version  = local.kubernetes_version
     logging_types       = var.logging_types
 
     dynamic "node_groups" {

--- a/modules/downstream/aws/EKS/provider.tf
+++ b/modules/downstream/aws/EKS/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  access_key = var.aws_access_key != null ? var.aws_access_key : null
+  secret_key = var.aws_secret_key != null ? var.aws_secret_key : null
+  region     = var.aws_region
+}

--- a/modules/downstream/aws/EKS/versions.tf
+++ b/modules/downstream/aws/EKS/versions.tf
@@ -4,5 +4,13 @@ terraform {
       source  = "rancher/rancher2"
       version = ">= 8.0.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0.0"
+    }
   }
 }

--- a/modules/downstream/aws/EKS/versions.tf
+++ b/modules/downstream/aws/EKS/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.10"
   required_providers {
     rancher2 = {
       source  = "rancher/rancher2"
@@ -6,7 +7,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = ">= 5.0.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/rancher/versions.tf
+++ b/modules/rancher/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.10"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/recipes/downstream/aws/EKS/versions.tf
+++ b/recipes/downstream/aws/EKS/versions.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "rancher/rancher2"
       version = ">= 8.0.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
   }
 }

--- a/recipes/downstream/aws/EKS/versions.tf
+++ b/recipes/downstream/aws/EKS/versions.tf
@@ -4,9 +4,5 @@ terraform {
       source  = "rancher/rancher2"
       version = ">= 8.0.0"
     }
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.0.0"
-    }
   }
 }

--- a/recipes/downstream/aws/v2/versions.tf
+++ b/recipes/downstream/aws/v2/versions.tf
@@ -6,4 +6,3 @@ terraform {
     }
   }
 }
-


### PR DESCRIPTION
Add EKS version from datasource as default

Added `null_resource` to ignore changes in the datasource version -- to prevent unexpected upgrades, these can be applied using the `kubernetes_version`