### PR TITLE
Add default AWS AMI as fallback for downstream/v2

### DIFF
--- a/modules/downstream/aws/v2/data.tf
+++ b/modules/downstream/aws/v2/data.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region                      = var.aws_region
+  access_key                  = var.aws_access_key != null ? var.aws_access_key : (var.ami != null ? "mock" : null)
+  secret_key                  = var.aws_secret_key != null ? var.aws_secret_key : (var.ami != null ? "mock" : null)
+  skip_credentials_validation = var.ami != null ? true : false
+  skip_requesting_account_id  = var.ami != null ? true : false
+}
+
+data "aws_ssm_parameter" "sles" {
+  count = var.ami == null && var.os_type == "sles" ? 1 : 0
+  name  = "/aws/service/suse/sles-byos/${var.sles_version}/x86_64/latest"
+}
+
+data "aws_ssm_parameter" "ubuntu" {
+  count = var.ami == null && var.os_type == "ubuntu" ? 1 : 0
+  name  = "/aws/service/canonical/ubuntu/server/${var.ubuntu_version}/stable/current/amd64/hvm/ebs-gp2/ami-id"
+}

--- a/modules/downstream/aws/v2/main.tf
+++ b/modules/downstream/aws/v2/main.tf
@@ -1,5 +1,5 @@
 locals {
-  ami = var.ami != null ? var.ami : (var.os_type == "ubuntu" ? data.aws_ssm_parameter.ubuntu[0].value : data.aws_ssm_parameter.sles[0].value)
+  ami = var.ami != null ? var.ami : (var.os_type == "ubuntu" ? data.aws_ssm_parameter.ubuntu[0].insecure_value : data.aws_ssm_parameter.sles[0].insecure_value)
 }
 
 resource "rancher2_cloud_credential" "aws_credential" {

--- a/modules/downstream/aws/v2/main.tf
+++ b/modules/downstream/aws/v2/main.tf
@@ -1,3 +1,7 @@
+locals {
+  ami = var.ami != null ? var.ami : (var.os_type == "ubuntu" ? data.aws_ssm_parameter.ubuntu[0].value : data.aws_ssm_parameter.sles[0].value)
+}
+
 resource "rancher2_cloud_credential" "aws_credential" {
   count       = var.cloud_credential_id != null ? 0 : 1
   name        = var.cluster_name
@@ -11,7 +15,7 @@ resource "rancher2_cloud_credential" "aws_credential" {
 resource "rancher2_machine_config_v2" "machine_config" {
   generate_name = var.cluster_name
   amazonec2_config {
-    ami                   = var.ami
+    ami                   = local.ami
     region                = var.aws_region
     security_group        = [var.security_group_name]
     subnet_id             = var.subnet_id

--- a/modules/downstream/aws/v2/variables.tf
+++ b/modules/downstream/aws/v2/variables.tf
@@ -154,3 +154,24 @@ variable "ami" {
     error_message = "The ami value must be a valid AMI id, starting with \"ami-\"."
   }
 }
+variable "os_type" {
+  type        = string
+  description = "Use SLES or Ubuntu images when launching instances (sles or ubuntu)"
+  default     = "ubuntu"
+  validation {
+    condition     = contains(["sles", "ubuntu"], var.os_type)
+    error_message = "The operating system type must be 'sles' or 'ubuntu'."
+  }
+}
+
+variable "sles_version" {
+  type        = string
+  description = "Version of SLES to use for instances (ex: 15-sp6)"
+  default     = "15-sp6"
+}
+
+variable "ubuntu_version" {
+  type        = string
+  description = "Version of Ubuntu to use for instances (ex: 22.04)"
+  default     = "22.04"
+}

--- a/modules/downstream/aws/v2/variables.tf
+++ b/modules/downstream/aws/v2/variables.tf
@@ -150,7 +150,7 @@ variable "ami" {
   description = "AMI to use when launching nodes"
 
   validation {
-    condition     = can(regex("^ami-[[:alnum:]]{10}", var.ami))
+    condition     = var.ami == null ? true : can(regex("^ami-[[:alnum:]]{10}", var.ami))
     error_message = "The ami value must be a valid AMI id, starting with \"ami-\"."
   }
 }

--- a/modules/downstream/aws/v2/versions.tf
+++ b/modules/downstream/aws/v2/versions.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "rancher/rancher2"
       version = ">= 8.0.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
   }
 }

--- a/modules/downstream/aws/v2/versions.tf
+++ b/modules/downstream/aws/v2/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = ">= 5.0.0"
     }
   }
 }

--- a/recipes/downstream/aws/v2/main.tf
+++ b/recipes/downstream/aws/v2/main.tf
@@ -11,9 +11,13 @@ module "downstream_rke2" {
   security_group_name = var.security_group_name
   ssh_user            = var.ssh_user
   ami                 = var.ami
-  instance_type       = var.instance_type
-  volume_size         = var.volume_size
-  spot_instances      = var.spot_instances
+  os_type             = var.os_type
+  sles_version        = var.sles_version
+  ubuntu_version      = var.ubuntu_version
+
+  instance_type  = var.instance_type
+  volume_size    = var.volume_size
+  spot_instances = var.spot_instances
 
   cluster_name          = var.cluster_name
   kubernetes_version    = var.kubernetes_version

--- a/recipes/downstream/aws/v2/variables.tf
+++ b/recipes/downstream/aws/v2/variables.tf
@@ -179,7 +179,7 @@ variable "ami" {
   description = "AMI to use when launching nodes"
 
   validation {
-    condition     = can(regex("^ami-[[:alnum:]]{10}", var.ami))
+    condition     = var.ami == null ? true : can(regex("^ami-[[:alnum:]]{10}", var.ami))
     error_message = "The ami value must be a valid AMI id, starting with \"ami-\"."
   }
 }

--- a/recipes/downstream/aws/v2/variables.tf
+++ b/recipes/downstream/aws/v2/variables.tf
@@ -183,3 +183,25 @@ variable "ami" {
     error_message = "The ami value must be a valid AMI id, starting with \"ami-\"."
   }
 }
+
+variable "os_type" {
+  type        = string
+  description = "Use SLES or Ubuntu images when launching instances (sles or ubuntu)"
+  default     = "ubuntu"
+  validation {
+    condition     = contains(["sles", "ubuntu"], var.os_type)
+    error_message = "The operating system type must be 'sles' or 'ubuntu'."
+  }
+}
+
+variable "sles_version" {
+  type        = string
+  description = "Version of SLES to use for instances (ex: 15-sp6)"
+  default     = "15-sp6"
+}
+
+variable "ubuntu_version" {
+  type        = string
+  description = "Version of Ubuntu to use for instances (ex: 22.04)"
+  default     = "22.04"
+}


### PR DESCRIPTION
Similar to the upstream recipes/modules, to simplify deployment the current stable AMI is retrieved if no `var.ami` is set.