### PR TITLE
Fix Rancher ingress class in AWS RKE2 recipe

### DIFF
--- a/recipes/upstream/aws/rke2/main.tf
+++ b/recipes/upstream/aws/rke2/main.tf
@@ -104,7 +104,8 @@ resource "local_file" "kube_config_yaml_backup" {
 }
 
 locals {
-  rancher_hostname = join(".", ["rancher", module.rke2_first_server.instances_public_ip[0], "sslip.io"])
+  rancher_hostname      = join(".", ["rancher", module.rke2_first_server.instances_public_ip[0], "sslip.io"])
+  rancher_ingress_class = var.rke2_ingress == "ingress-nginx" ? "nginx" : var.rke2_ingress
 }
 
 module "rancher_install" {
@@ -125,6 +126,6 @@ module "rancher_install" {
   wait                                  = var.wait
   rancher_additional_helm_values = [
     "replicas: ${var.instance_count}",
-    "ingress.ingressClassName: ${var.rke2_ingress}"
+    "ingress.ingressClassName: ${local.rancher_ingress_class}"
   ]
 }


### PR DESCRIPTION
## Summary

- Map the RKE2 ingress selector ingress-nginx to the Kubernetes IngressClass name nginx when configuring the Rancher chart.
- Preserve the existing class name for Traefik deployments.

## Reproduction

1. Deploy recipes/upstream/aws/rke2 with the default rke2_ingress value.
2. Observe that RKE2 registers an IngressClass named nginx, while the Rancher ingress requests ingress-nginx.
3. Requests to the Rancher /ping endpoint reach the ingress controller default backend and return HTTP 404.

## Validation

- terraform fmt -check recipes/upstream/aws/rke2/main.tf
- terraform -chdir=recipes/upstream/aws/rke2 validate
- Confirmed on an RKE2 cluster that the controller is configured with --ingress-class=nginx.